### PR TITLE
주문·장바구니 도메인을 order-api 모듈로 분리

### DIFF
--- a/apps/order-api/src/main/java/com/loopers/domain/cart/Cart.java
+++ b/apps/order-api/src/main/java/com/loopers/domain/cart/Cart.java
@@ -19,7 +19,7 @@ public class Cart extends BaseEntity {
     @Column(name = "user_id", nullable = false, unique = true)
     private Long userId;
 
-    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private List<CartItem> items = new ArrayList<>();
 
     @Builder

--- a/apps/order-api/src/test/java/com/loopers/domain/cart/CartServiceTest.java
+++ b/apps/order-api/src/test/java/com/loopers/domain/cart/CartServiceTest.java
@@ -1,0 +1,297 @@
+package com.loopers.domain.cart;
+
+import com.loopers.domain.cart.port.ProductPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CartServiceTest {
+
+    @InjectMocks
+    CartService cartService;
+
+    @Mock
+    CartRepository cartRepository;
+
+    @Mock
+    ProductPort productPort;
+
+    private Cart createCartWithItem(Long userId, Long itemId, Long productId, Long quantity, Long price) {
+        Cart cart = Cart.create(userId);
+        ReflectionTestUtils.setField(cart, "id", 1L);
+        CartItem item = CartItem.create(productId, quantity, price);
+        ReflectionTestUtils.setField(item, "id", itemId);
+        cart.addItem(item);
+        return cart;
+    }
+
+    @Nested
+    @DisplayName("addItem")
+    class AddItem {
+
+        @Test
+        @DisplayName("장바구니가 없으면 새로 생성 후 아이템을 추가한다")
+        void addItem_newCart() {
+            // given
+            Long userId = 1L;
+            Long productId = 100L;
+            Long quantity = 2L;
+            ProductPort.ProductInfo productInfo = new ProductPort.ProductInfo(productId, "상품A", 5000L, "http://img.com/a.jpg");
+
+            when(productPort.getProduct(productId)).thenReturn(productInfo);
+            when(cartRepository.findByUserId(userId)).thenReturn(Optional.empty());
+            when(cartRepository.save(any(Cart.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            Cart result = cartService.addItem(userId, productId, quantity);
+
+            // then
+            assertAll(
+                    () -> assertThat(result.getItems()).hasSize(1),
+                    () -> assertThat(result.getItems().get(0).getProductId()).isEqualTo(productId),
+                    () -> assertThat(result.getItems().get(0).getQuantity()).isEqualTo(quantity),
+                    () -> assertThat(result.getItems().get(0).getPrice()).isEqualTo(5000L)
+            );
+            verify(cartRepository, times(2)).save(any(Cart.class));
+        }
+
+        @Test
+        @DisplayName("같은 상품이 있으면 수량을 증가시킨다")
+        void addItem_existingProduct_increaseQuantity() {
+            // given
+            Long userId = 1L;
+            Long productId = 100L;
+            Long additionalQuantity = 3L;
+            Cart cart = createCartWithItem(userId, 1L, productId, 2L, 5000L);
+
+            ProductPort.ProductInfo productInfo = new ProductPort.ProductInfo(productId, "상품A", 5000L, "http://img.com/a.jpg");
+            when(productPort.getProduct(productId)).thenReturn(productInfo);
+            when(cartRepository.findByUserId(userId)).thenReturn(Optional.of(cart));
+            when(cartRepository.save(any(Cart.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            Cart result = cartService.addItem(userId, productId, additionalQuantity);
+
+            // then
+            assertAll(
+                    () -> assertThat(result.getItems()).hasSize(1),
+                    () -> assertThat(result.getItems().get(0).getQuantity()).isEqualTo(5L) // 2 + 3
+            );
+        }
+
+        @Test
+        @DisplayName("다른 상품이면 새 아이템을 추가한다")
+        void addItem_differentProduct_addNew() {
+            // given
+            Long userId = 1L;
+            Long existingProductId = 100L;
+            Long newProductId = 200L;
+            Cart cart = createCartWithItem(userId, 1L, existingProductId, 2L, 5000L);
+
+            ProductPort.ProductInfo productInfo = new ProductPort.ProductInfo(newProductId, "상품B", 10000L, "http://img.com/b.jpg");
+            when(productPort.getProduct(newProductId)).thenReturn(productInfo);
+            when(cartRepository.findByUserId(userId)).thenReturn(Optional.of(cart));
+            when(cartRepository.save(any(Cart.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            Cart result = cartService.addItem(userId, newProductId, 1L);
+
+            // then
+            assertThat(result.getItems()).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("getCart")
+    class GetCart {
+
+        @Test
+        @DisplayName("장바구니가 있으면 반환한다")
+        void getCart_exists() {
+            // given
+            Long userId = 1L;
+            Cart cart = Cart.create(userId);
+            when(cartRepository.findByUserId(userId)).thenReturn(Optional.of(cart));
+
+            // when
+            Cart result = cartService.getCart(userId);
+
+            // then
+            assertThat(result.getUserId()).isEqualTo(userId);
+        }
+
+        @Test
+        @DisplayName("장바구니가 없으면 빈 Cart를 반환한다")
+        void getCart_notExists() {
+            // given
+            Long userId = 1L;
+            when(cartRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+            // when
+            Cart result = cartService.getCart(userId);
+
+            // then
+            assertAll(
+                    () -> assertThat(result.getUserId()).isEqualTo(userId),
+                    () -> assertThat(result.getItems()).isEmpty()
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("updateItemQuantity")
+    class UpdateItemQuantity {
+
+        @Test
+        @DisplayName("아이템이 있으면 수량을 변경한다")
+        void updateItemQuantity_success() {
+            // given
+            Long itemId = 1L;
+            Long newQuantity = 5L;
+            CartItem item = CartItem.create(100L, 2L, 5000L);
+            ReflectionTestUtils.setField(item, "id", itemId);
+
+            when(cartRepository.findItemById(itemId)).thenReturn(Optional.of(item));
+
+            // when
+            cartService.updateItemQuantity(itemId, newQuantity);
+
+            // then
+            assertThat(item.getQuantity()).isEqualTo(newQuantity);
+        }
+
+        @Test
+        @DisplayName("아이템이 없으면 IllegalArgumentException이 발생한다")
+        void updateItemQuantity_notFound() {
+            // given
+            Long itemId = 999L;
+            when(cartRepository.findItemById(itemId)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> cartService.updateItemQuantity(itemId, 5L))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("removeItem")
+    class RemoveItem {
+
+        @Test
+        @DisplayName("아이템이 있으면 삭제한다")
+        void removeItem_success() {
+            // given
+            Long userId = 1L;
+            Long itemId = 1L;
+            CartItem item = CartItem.create(100L, 2L, 5000L);
+            ReflectionTestUtils.setField(item, "id", itemId);
+
+            when(cartRepository.findItemById(itemId)).thenReturn(Optional.of(item));
+
+            // when
+            cartService.removeItem(userId, itemId);
+
+            // then
+            verify(cartRepository).deleteItem(item);
+        }
+
+        @Test
+        @DisplayName("아이템이 없으면 IllegalArgumentException이 발생한다")
+        void removeItem_notFound() {
+            // given
+            Long userId = 1L;
+            Long itemId = 999L;
+            when(cartRepository.findItemById(itemId)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> cartService.removeItem(userId, itemId))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("clearCart")
+    class ClearCart {
+
+        @Test
+        @DisplayName("장바구니가 있으면 삭제한다")
+        void clearCart_exists() {
+            // given
+            Long userId = 1L;
+            Cart cart = Cart.create(userId);
+            when(cartRepository.findByUserId(userId)).thenReturn(Optional.of(cart));
+
+            // when
+            cartService.clearCart(userId);
+
+            // then
+            verify(cartRepository).deleteCart(cart);
+        }
+
+        @Test
+        @DisplayName("장바구니가 없으면 아무 동작도 하지 않는다")
+        void clearCart_notExists() {
+            // given
+            Long userId = 1L;
+            when(cartRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+            // when
+            cartService.clearCart(userId);
+
+            // then
+            verify(cartRepository, never()).deleteCart(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("getCartCount")
+    class GetCartCount {
+
+        @Test
+        @DisplayName("장바구니 아이템의 수량 합계를 반환한다")
+        void getCartCount_withItems() {
+            // given
+            Long userId = 1L;
+            Cart cart = Cart.create(userId);
+            cart.addItem(CartItem.create(100L, 2L, 5000L));
+            cart.addItem(CartItem.create(200L, 3L, 10000L));
+
+            when(cartRepository.findByUserId(userId)).thenReturn(Optional.of(cart));
+
+            // when
+            Long count = cartService.getCartCount(userId);
+
+            // then
+            assertThat(count).isEqualTo(5L); // 2 + 3
+        }
+
+        @Test
+        @DisplayName("장바구니가 없으면 0을 반환한다")
+        void getCartCount_notExists() {
+            // given
+            Long userId = 1L;
+            when(cartRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+            // when
+            Long count = cartService.getCartCount(userId);
+
+            // then
+            assertThat(count).isEqualTo(0L);
+        }
+    }
+}

--- a/apps/order-api/src/test/java/com/loopers/domain/cart/CartTest.java
+++ b/apps/order-api/src/test/java/com/loopers/domain/cart/CartTest.java
@@ -1,0 +1,177 @@
+package com.loopers.domain.cart;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class CartTest {
+
+    @Nested
+    @DisplayName("Cart 생성")
+    class Create {
+
+        @Test
+        @DisplayName("userId로 생성하면 빈 아이템 목록을 가진다")
+        void create_withUserId() {
+            // given
+            Long userId = 1L;
+
+            // when
+            Cart cart = Cart.create(userId);
+
+            // then
+            assertAll(
+                    () -> assertThat(cart.getUserId()).isEqualTo(userId),
+                    () -> assertThat(cart.getItems()).isEmpty()
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("아이템 추가")
+    class AddItem {
+
+        @Test
+        @DisplayName("CartItem을 추가하면 items에 포함된다")
+        void addItem_single() {
+            // given
+            Cart cart = Cart.create(1L);
+            CartItem item = CartItem.create(100L, 2L, 5000L);
+
+            // when
+            cart.addItem(item);
+
+            // then
+            assertAll(
+                    () -> assertThat(cart.getItems()).hasSize(1),
+                    () -> assertThat(item.getCart()).isEqualTo(cart)
+            );
+        }
+
+        @Test
+        @DisplayName("여러 아이템을 추가하면 모두 포함된다")
+        void addItem_multiple() {
+            // given
+            Cart cart = Cart.create(1L);
+            CartItem item1 = CartItem.create(100L, 1L, 5000L);
+            CartItem item2 = CartItem.create(200L, 2L, 10000L);
+            CartItem item3 = CartItem.create(300L, 3L, 15000L);
+
+            // when
+            cart.addItem(item1);
+            cart.addItem(item2);
+            cart.addItem(item3);
+
+            // then
+            assertThat(cart.getItems()).hasSize(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("아이템 삭제")
+    class RemoveItem {
+
+        @Test
+        @DisplayName("삭제하면 items에서 제거된다")
+        void removeItem_success() {
+            // given
+            Cart cart = Cart.create(1L);
+            CartItem item = CartItem.create(100L, 2L, 5000L);
+            cart.addItem(item);
+
+            // when
+            cart.removeItem(item);
+
+            // then
+            assertAll(
+                    () -> assertThat(cart.getItems()).isEmpty(),
+                    () -> assertThat(item.getCart()).isNull()
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 비우기")
+    class ClearItems {
+
+        @Test
+        @DisplayName("clearItems 호출 시 모든 아이템이 제거된다")
+        void clearItems_success() {
+            // given
+            Cart cart = Cart.create(1L);
+            cart.addItem(CartItem.create(100L, 1L, 5000L));
+            cart.addItem(CartItem.create(200L, 2L, 10000L));
+
+            // when
+            cart.clearItems();
+
+            // then
+            assertThat(cart.getItems()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("총 금액 계산")
+    class GetTotalAmount {
+
+        @Test
+        @DisplayName("price * quantity 합계를 반환한다")
+        void getTotalAmount_withItems() {
+            // given
+            Cart cart = Cart.create(1L);
+            cart.addItem(CartItem.create(100L, 2L, 5000L));   // 10000
+            cart.addItem(CartItem.create(200L, 1L, 10000L));  // 10000
+
+            // when
+            Long totalAmount = cart.getTotalAmount();
+
+            // then
+            assertThat(totalAmount).isEqualTo(20000L);
+        }
+
+        @Test
+        @DisplayName("빈 Cart는 0을 반환한다")
+        void getTotalAmount_empty() {
+            // given
+            Cart cart = Cart.create(1L);
+
+            // when
+            Long totalAmount = cart.getTotalAmount();
+
+            // then
+            assertThat(totalAmount).isEqualTo(0L);
+        }
+    }
+
+    @Nested
+    @DisplayName("CartItem")
+    class CartItemTest {
+
+        @Test
+        @DisplayName("create, updateQuantity, getSubtotal이 정상 동작한다")
+        void cartItem_operations() {
+            // given
+            CartItem item = CartItem.create(100L, 2L, 5000L);
+
+            // then - create 검증
+            assertAll(
+                    () -> assertThat(item.getProductId()).isEqualTo(100L),
+                    () -> assertThat(item.getQuantity()).isEqualTo(2L),
+                    () -> assertThat(item.getPrice()).isEqualTo(5000L),
+                    () -> assertThat(item.getSubtotal()).isEqualTo(10000L)
+            );
+
+            // when - updateQuantity
+            item.updateQuantity(5L);
+
+            // then
+            assertAll(
+                    () -> assertThat(item.getQuantity()).isEqualTo(5L),
+                    () -> assertThat(item.getSubtotal()).isEqualTo(25000L)
+            );
+        }
+    }
+}

--- a/apps/order-api/src/test/java/com/loopers/interfaces/api/cart/CartV1ApiE2ETest.java
+++ b/apps/order-api/src/test/java/com/loopers/interfaces/api/cart/CartV1ApiE2ETest.java
@@ -1,0 +1,338 @@
+package com.loopers.interfaces.api.cart;
+
+import com.loopers.annotation.SprintE2ETest;
+import com.loopers.domain.cart.Cart;
+import com.loopers.domain.cart.CartItem;
+import com.loopers.infrastructure.feign.commerce.CommerceApiClient;
+import com.loopers.infrastructure.feign.commerce.CommerceApiDto;
+import com.loopers.interfaces.api.ApiHeaders;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.utils.DatabaseCleanUp;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@RequiredArgsConstructor
+@SprintE2ETest
+class CartV1ApiE2ETest {
+
+    private static final String BASE_URL = "/api/v1/cart";
+    private static final String USER_ID = "testuser";
+    private static final Long USER_DB_ID = 1L;
+
+    private final DatabaseCleanUp databaseCleanUp;
+    private final TestRestTemplate testRestTemplate;
+    private final TestEntityManager testEntityManager;
+    private final TransactionTemplate transactionTemplate;
+
+    @MockitoBean
+    private CommerceApiClient commerceApiClient;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    private HttpHeaders createHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(ApiHeaders.USER_ID, USER_ID);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+
+    private void mockUser() {
+        CommerceApiDto.UserResponse user = new CommerceApiDto.UserResponse(USER_DB_ID, USER_ID, "test@test.com");
+        when(commerceApiClient.getUser(USER_ID)).thenReturn(ApiResponse.success(user));
+    }
+
+    private void mockGetProducts(Long productId, String name, Long price) {
+        CommerceApiDto.ProductResponse product = new CommerceApiDto.ProductResponse(productId, name, price, "http://img.com/a.jpg");
+        when(commerceApiClient.getProducts(any())).thenReturn(ApiResponse.success(List.of(product)));
+    }
+
+    private Cart persistCartWithItems() {
+        Cart cart = Cart.create(USER_DB_ID);
+        CartItem item1 = CartItem.create(10L, 2L, 5000L);
+        CartItem item2 = CartItem.create(20L, 1L, 20000L);
+        cart.addItem(item1);
+        cart.addItem(item2);
+        transactionTemplate.executeWithoutResult(status -> testEntityManager.persist(cart));
+        return cart;
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/cart")
+    class GetCart {
+
+        @Test
+        @DisplayName("아이템이 있으면 목록과 총 금액을 반환한다")
+        void getCart_withItems() {
+            // given
+            mockUser();
+            Cart cart = persistCartWithItems();
+
+            ParameterizedTypeReference<ApiResponse<CartV1Dto.Response.CartDetail>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<CartV1Dto.Response.CartDetail>> response =
+                    testRestTemplate.exchange(BASE_URL, HttpMethod.GET,
+                            new HttpEntity<>(null, createHeaders()), responseType);
+
+            // then
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data().items()).hasSize(2),
+                    () -> assertThat(response.getBody().data().totalAmount()).isEqualTo(30000L) // 5000*2 + 20000*1
+            );
+        }
+
+        @Test
+        @DisplayName("장바구니가 없으면 빈 장바구니를 반환한다")
+        void getCart_empty() {
+            // given
+            mockUser();
+
+            ParameterizedTypeReference<ApiResponse<CartV1Dto.Response.CartDetail>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<CartV1Dto.Response.CartDetail>> response =
+                    testRestTemplate.exchange(BASE_URL, HttpMethod.GET,
+                            new HttpEntity<>(null, createHeaders()), responseType);
+
+            // then
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data().items()).isEmpty(),
+                    () -> assertThat(response.getBody().data().totalAmount()).isEqualTo(0L)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/cart/items")
+    class AddItem {
+
+        @Test
+        @DisplayName("새 상품을 추가하면 장바구니에 포함된다")
+        void addItem_newProduct() {
+            // given
+            mockUser();
+            mockGetProducts(10L, "상품A", 5000L);
+
+            CartV1Dto.Request.AddItem request = new CartV1Dto.Request.AddItem(10L, 2L);
+
+            ParameterizedTypeReference<ApiResponse<CartV1Dto.Response.CartDetail>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<CartV1Dto.Response.CartDetail>> response =
+                    testRestTemplate.exchange(BASE_URL + "/items", HttpMethod.POST,
+                            new HttpEntity<>(request, createHeaders()), responseType);
+
+            // then
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data().items()).hasSize(1),
+                    () -> assertThat(response.getBody().data().items().get(0).productId()).isEqualTo(10L),
+                    () -> assertThat(response.getBody().data().items().get(0).quantity()).isEqualTo(2L)
+            );
+        }
+
+        @Test
+        @DisplayName("기존 상품을 추가하면 수량이 증가한다")
+        void addItem_existingProduct_increaseQuantity() {
+            // given
+            mockUser();
+            persistCartWithItems();
+            mockGetProducts(10L, "상품A", 5000L);
+
+            CartV1Dto.Request.AddItem request = new CartV1Dto.Request.AddItem(10L, 3L);
+
+            ParameterizedTypeReference<ApiResponse<CartV1Dto.Response.CartDetail>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<CartV1Dto.Response.CartDetail>> response =
+                    testRestTemplate.exchange(BASE_URL + "/items", HttpMethod.POST,
+                            new HttpEntity<>(request, createHeaders()), responseType);
+
+            // then
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data().items()).hasSize(2),
+                    () -> assertThat(response.getBody().data().items().stream()
+                            .filter(i -> i.productId().equals(10L))
+                            .findFirst()
+                            .orElseThrow()
+                            .quantity()).isEqualTo(5L) // 2 + 3
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/cart/items/{itemId}")
+    class UpdateItemQuantity {
+
+        @Test
+        @DisplayName("수량 변경에 성공한다")
+        void updateItemQuantity_success() {
+            // given
+            mockUser();
+            Cart cart = persistCartWithItems();
+            Long itemId = cart.getItems().get(0).getId();
+
+            CartV1Dto.Request.UpdateQuantity request = new CartV1Dto.Request.UpdateQuantity(10L);
+
+            ParameterizedTypeReference<ApiResponse<Void>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<Void>> response =
+                    testRestTemplate.exchange(BASE_URL + "/items/" + itemId, HttpMethod.PUT,
+                            new HttpEntity<>(request, createHeaders()), responseType);
+
+            // then
+            assertTrue(response.getStatusCode().is2xxSuccessful());
+        }
+
+        @Test
+        @DisplayName("없는 아이템이면 500 에러를 반환한다")
+        void updateItemQuantity_notFound() {
+            // given
+            mockUser();
+            CartV1Dto.Request.UpdateQuantity request = new CartV1Dto.Request.UpdateQuantity(10L);
+
+            ParameterizedTypeReference<ApiResponse<Void>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<Void>> response =
+                    testRestTemplate.exchange(BASE_URL + "/items/99999", HttpMethod.PUT,
+                            new HttpEntity<>(request, createHeaders()), responseType);
+
+            // then
+            assertTrue(response.getStatusCode().is5xxServerError());
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/cart/items/{itemId}")
+    class RemoveItem {
+
+        @Test
+        @DisplayName("아이템 삭제에 성공한다")
+        void removeItem_success() {
+            // given
+            mockUser();
+            Cart cart = persistCartWithItems();
+            Long itemId = cart.getItems().get(0).getId();
+
+            ParameterizedTypeReference<ApiResponse<Void>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<Void>> response =
+                    testRestTemplate.exchange(BASE_URL + "/items/" + itemId, HttpMethod.DELETE,
+                            new HttpEntity<>(null, createHeaders()), responseType);
+
+            // then
+            assertTrue(response.getStatusCode().is2xxSuccessful());
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/cart")
+    class ClearCart {
+
+        @Test
+        @DisplayName("장바구니 비우기에 성공한다")
+        void clearCart_success() {
+            // given
+            mockUser();
+            persistCartWithItems();
+
+            ParameterizedTypeReference<ApiResponse<Void>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<Void>> response =
+                    testRestTemplate.exchange(BASE_URL, HttpMethod.DELETE,
+                            new HttpEntity<>(null, createHeaders()), responseType);
+
+            // then
+            assertTrue(response.getStatusCode().is2xxSuccessful());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/cart/count")
+    class GetCartCount {
+
+        @Test
+        @DisplayName("총 수량을 반환한다")
+        void getCartCount_withItems() {
+            // given
+            mockUser();
+            persistCartWithItems();
+
+            ParameterizedTypeReference<ApiResponse<CartV1Dto.Response.CartCount>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<CartV1Dto.Response.CartCount>> response =
+                    testRestTemplate.exchange(BASE_URL + "/count", HttpMethod.GET,
+                            new HttpEntity<>(null, createHeaders()), responseType);
+
+            // then
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data().count()).isEqualTo(3L) // 2 + 1
+            );
+        }
+
+        @Test
+        @DisplayName("장바구니가 없으면 0을 반환한다")
+        void getCartCount_empty() {
+            // given
+            mockUser();
+
+            ParameterizedTypeReference<ApiResponse<CartV1Dto.Response.CartCount>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<CartV1Dto.Response.CartCount>> response =
+                    testRestTemplate.exchange(BASE_URL + "/count", HttpMethod.GET,
+                            new HttpEntity<>(null, createHeaders()), responseType);
+
+            // then
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data().count()).isEqualTo(0L)
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **order-api 모듈 신규 생성** (포트 8081): 주문·장바구니 도메인을 독립 모듈로 분리
- **주문/장바구니 도메인·서비스·인프라·API 코드 이동**: commerce-api → order-api
- **양방향 Feign 통신** 구성: order-api ↔ commerce-api 간 Internal API 컨트롤러 추가
- **테스트 작성**: Order(엔티티·서비스·Facade·E2E) + Cart(엔티티·서비스·E2E)

## Test plan
- [x] Order 도메인 단위 테스트 통과
- [x] OrderService 서비스 테스트 통과
- [x] OrderFacade 통합 테스트 통과
- [x] OrderV1Api E2E 테스트 통과
- [x] Cart 도메인 단위 테스트 통과
- [x] CartService 서비스 테스트 통과
- [x] CartV1Api E2E 테스트 통과
- [x] commerce-api 기존 테스트 정상 동작 확인

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)