### PR TITLE
feat(pbo): PBO API 모듈 초기 셋업

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ docker-compose -f ./docker/monitoring-compose.yml up
   - commerce-api (포트 8080): `./gradlew :apps:commerce-api:bootRun`
   - order-api (포트 8081): `./gradlew :apps:order-api:bootRun`
   - like-api (포트 8083): `./gradlew :apps:like-api:bootRun`
+  - pbo-api (포트 8084): `./gradlew :apps:pbo-api:bootRun`
 - **API 테스트**: `http/` 디렉터리의 `.http` 파일과 `http-client.env.json`을 사용합니다.
 
 ### 시드 데이터 (local)
@@ -102,6 +103,7 @@ Root
 │   ├── commerce-api      # 상품, 결제, 쿠폰, 랭킹, 리뷰 등 (포트 8080)
 │   ├── order-api         # 주문, 장바구니 (포트 8081)
 │   ├── like-api          # 좋아요 (포트 8083)
+│   ├── pbo-api           # PBO 물류·재고·매장 운영 (포트 8084)
 │   ├── commerce-collector # 이벤트 수집·메트릭
 │   ├── commerce-batch    # 배치 작업
 │   └── pg-simulator      # PG 결제 시뮬레이터 (Kotlin, 포트 8082)

--- a/apps/pbo-api/build.gradle.kts
+++ b/apps/pbo-api/build.gradle.kts
@@ -1,0 +1,27 @@
+tasks.named("bootRun") {
+    dependsOn(rootProject.tasks.named("infraUp"))
+}
+
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":modules:feign"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
+    implementation("org.springframework.boot:spring-boot-starter-validation:3.5.0")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
+
+    // archunit
+    testImplementation("com.tngtech.archunit:archunit-junit5:${project.properties["archunitVersion"]}")
+}

--- a/apps/pbo-api/src/main/java/com/loopers/PboApiApplication.java
+++ b/apps/pbo-api/src/main/java/com/loopers/PboApiApplication.java
@@ -1,0 +1,24 @@
+package com.loopers;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+
+import java.util.TimeZone;
+
+@ConfigurationPropertiesScan
+@SpringBootApplication
+@EnableFeignClients
+public class PboApiApplication {
+
+    @PostConstruct
+    public void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(PboApiApplication.class, args);
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/pbo-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -1,0 +1,143 @@
+package com.loopers.interfaces.api;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.server.ServerWebInputException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+@Slf4j
+public class ApiControllerAdvice {
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handle(CoreException e) {
+        log.warn("CoreException : {}", e.getCustomMessage() != null ? e.getCustomMessage() : e.getMessage(), e);
+        return failureResponse(e.getErrorType(), e.getCustomMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(MethodArgumentTypeMismatchException e) {
+        String name = e.getName();
+        String type = e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "unknown";
+        String value = e.getValue() != null ? e.getValue().toString() : "null";
+        String message = String.format("요청 파라미터 '%s' (타입: %s)의 값 '%s'이(가) 잘못되었습니다.", name, type, value);
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(MissingServletRequestParameterException e) {
+        String name = e.getParameterName();
+        String type = e.getParameterType();
+        String message = String.format("필수 요청 파라미터 '%s' (타입: %s)가 누락되었습니다.", name, type);
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(MissingRequestHeaderException e) {
+        String headerName = e.getHeaderName();
+        String message = String.format("필수 요청 헤더 '%s'가 누락되었습니다.", headerName);
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(HttpMessageNotReadableException e) {
+        String errorMessage;
+        Throwable rootCause = e.getRootCause();
+
+        if (rootCause instanceof InvalidFormatException invalidFormat) {
+            String fieldName = invalidFormat.getPath().stream()
+                .map(ref -> ref.getFieldName() != null ? ref.getFieldName() : "?")
+                .collect(Collectors.joining("."));
+
+            String valueIndicationMessage = "";
+            if (invalidFormat.getTargetType().isEnum()) {
+                Class<?> enumClass = invalidFormat.getTargetType();
+                String enumValues = Arrays.stream(enumClass.getEnumConstants())
+                    .map(Object::toString)
+                    .collect(Collectors.joining(", "));
+                valueIndicationMessage = "사용 가능한 값 : [" + enumValues + "]";
+            }
+
+            String expectedType = invalidFormat.getTargetType().getSimpleName();
+            Object value = invalidFormat.getValue();
+
+            errorMessage = String.format("필드 '%s'의 값 '%s'이(가) 예상 타입(%s)과 일치하지 않습니다. %s",
+                fieldName, value, expectedType, valueIndicationMessage);
+
+        } else if (rootCause instanceof MismatchedInputException mismatchedInput) {
+            String fieldPath = mismatchedInput.getPath().stream()
+                .map(ref -> ref.getFieldName() != null ? ref.getFieldName() : "?")
+                .collect(Collectors.joining("."));
+            errorMessage = String.format("필수 필드 '%s'이(가) 누락되었습니다.", fieldPath);
+
+        } else if (rootCause instanceof JsonMappingException jsonMapping) {
+            String fieldPath = jsonMapping.getPath().stream()
+                .map(ref -> ref.getFieldName() != null ? ref.getFieldName() : "?")
+                .collect(Collectors.joining("."));
+            errorMessage = String.format("필드 '%s'에서 JSON 매핑 오류가 발생했습니다: %s",
+                fieldPath, jsonMapping.getOriginalMessage());
+
+        } else {
+            errorMessage = "요청 본문을 처리하는 중 오류가 발생했습니다. JSON 메세지 규격을 확인해주세요.";
+        }
+
+        return failureResponse(ErrorType.BAD_REQUEST, errorMessage);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(ServerWebInputException e) {
+        String missingParams = extractMissingParameter(e.getReason() != null ? e.getReason() : "");
+        if (!missingParams.isEmpty()) {
+            String message = String.format("필수 요청 값 '%s'가 누락되었습니다.", missingParams);
+            return failureResponse(ErrorType.BAD_REQUEST, message);
+        } else {
+            return failureResponse(ErrorType.BAD_REQUEST, null);
+        }
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleNotFound(NoResourceFoundException e) {
+        return failureResponse(ErrorType.NOT_FOUND, null);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handle(Throwable e) {
+        log.error("Exception : {}", e.getMessage(), e);
+        return failureResponse(ErrorType.INTERNAL_ERROR, null);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<?>> handleConstraintViolation(ConstraintViolationException e) {
+        String message = e.getConstraintViolations().stream()
+            .map(violation -> String.format("'%s' %s", violation.getPropertyPath(), violation.getMessage()))
+            .collect(Collectors.joining(", "));
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    private String extractMissingParameter(String message) {
+        Pattern pattern = Pattern.compile("'(.+?)'");
+        Matcher matcher = pattern.matcher(message);
+        return matcher.find() ? matcher.group(1) : "";
+    }
+
+    private ResponseEntity<ApiResponse<?>> failureResponse(ErrorType errorType, String errorMessage) {
+        return ResponseEntity.status(errorType.getStatus())
+            .body(ApiResponse.fail(errorType.getCode(), errorMessage != null ? errorMessage : errorType.getMessage()));
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/interfaces/api/ApiHeaders.java
+++ b/apps/pbo-api/src/main/java/com/loopers/interfaces/api/ApiHeaders.java
@@ -1,0 +1,5 @@
+package com.loopers.interfaces.api;
+
+public interface ApiHeaders {
+  String USER_ID = "X-USER-ID";
+}

--- a/apps/pbo-api/src/main/java/com/loopers/interfaces/api/ApiResponse.java
+++ b/apps/pbo-api/src/main/java/com/loopers/interfaces/api/ApiResponse.java
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api;
+
+public record ApiResponse<T>(Metadata meta, T data) {
+    public record Metadata(Result result, String errorCode, String message) {
+        public enum Result {
+            SUCCESS, FAIL
+        }
+
+        public static Metadata success() {
+            return new Metadata(Result.SUCCESS, null, null);
+        }
+
+        public static Metadata fail(String errorCode, String errorMessage) {
+            return new Metadata(Result.FAIL, errorCode, errorMessage);
+        }
+    }
+
+    public static ApiResponse<Object> success() {
+        return new ApiResponse<>(Metadata.success(), null);
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(Metadata.success(), data);
+    }
+
+    public static ApiResponse<Object> fail(String errorCode, String errorMessage) {
+        return new ApiResponse<>(
+            Metadata.fail(errorCode, errorMessage),
+            null
+        );
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/support/config/CorsConfig.java
+++ b/apps/pbo-api/src/main/java/com/loopers/support/config/CorsConfig.java
@@ -1,0 +1,33 @@
+package com.loopers.support.config;
+
+import com.loopers.interfaces.api.ApiHeaders;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.setAllowedOrigins(List.of("http://localhost:3000"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(
+                List.of(
+                        "Content-Type",
+                        "Authorization",
+                        ApiHeaders.USER_ID
+                ));
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/support/config/MdcLoggingFilter.java
+++ b/apps/pbo-api/src/main/java/com/loopers/support/config/MdcLoggingFilter.java
@@ -1,0 +1,54 @@
+package com.loopers.support.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class MdcLoggingFilter extends OncePerRequestFilter {
+
+    private static final String MDC_METHOD = "method";
+    private static final String MDC_REQUEST_URI = "requestUri";
+    private static final String MDC_CLIENT_IP = "clientIp";
+    private static final String MDC_USER_ID = "userId";
+
+    private static final String HEADER_X_FORWARDED_FOR = "X-Forwarded-For";
+    private static final String HEADER_X_USER_ID = "X-USER-ID";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            MDC.put(MDC_METHOD, request.getMethod());
+            MDC.put(MDC_REQUEST_URI, request.getRequestURI());
+            MDC.put(MDC_CLIENT_IP, extractClientIp(request));
+
+            String userId = request.getHeader(HEADER_X_USER_ID);
+            if (userId != null && !userId.isBlank()) {
+                MDC.put(MDC_USER_ID, userId);
+            }
+
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(MDC_METHOD);
+            MDC.remove(MDC_REQUEST_URI);
+            MDC.remove(MDC_CLIENT_IP);
+            MDC.remove(MDC_USER_ID);
+        }
+    }
+
+    private String extractClientIp(HttpServletRequest request) {
+        String xff = request.getHeader(HEADER_X_FORWARDED_FOR);
+        if (xff != null && !xff.isBlank()) {
+            return xff.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/support/error/CoreException.java
+++ b/apps/pbo-api/src/main/java/com/loopers/support/error/CoreException.java
@@ -1,0 +1,19 @@
+package com.loopers.support.error;
+
+import lombok.Getter;
+
+@Getter
+public class CoreException extends RuntimeException {
+    private final ErrorType errorType;
+    private final String customMessage;
+
+    public CoreException(ErrorType errorType) {
+        this(errorType, null);
+    }
+
+    public CoreException(ErrorType errorType, String customMessage) {
+        super(customMessage != null ? customMessage : errorType.getMessage());
+        this.errorType = errorType;
+        this.customMessage = customMessage;
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/support/error/ErrorType.java
+++ b/apps/pbo-api/src/main/java/com/loopers/support/error/ErrorType.java
@@ -1,0 +1,18 @@
+package com.loopers.support.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorType {
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(), "일시적인 오류가 발생했습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.getReasonPhrase(), "존재하지 않는 요청입니다."),
+    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/apps/pbo-api/src/main/resources/application.yml
+++ b/apps/pbo-api/src/main/resources/application.yml
@@ -1,0 +1,69 @@
+server:
+  port: 8084
+  shutdown: graceful
+  tomcat:
+    threads:
+      max: 200
+      min-spare: 10
+    connection-timeout: 1m
+    max-connections: 8192
+    accept-count: 100
+    keep-alive-timeout: 60s
+  max-http-request-header-size: 8KB
+
+management:
+  server:
+    port: 18084
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: pbo-api
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - logging.yml
+      - redis.yml
+      - feign.yml
+      - monitoring.yml
+  datasource:
+    hikari:
+      connection-timeout: 3000
+      validation-timeout: 2000
+
+service:
+  commerce-api:
+    url: http://localhost:8080
+
+logging:
+  level:
+    io.github.resilience4j.retry: DEBUG
+    org.springframework.transaction.interceptor: WARN
+    org.springframework.orm.jpa.JpaTransactionManager: WARN
+    org.springframework.jdbc.datasource.DataSourceTransactionManager: WARN
+    org.hibernate.SQL: WARN
+    org.hibernate.orm.jdbc.bind: WARN
+
+springdoc:
+  use-fqn: true
+  swagger-ui:
+    path: /swagger-ui.html
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include(
     ":apps:commerce-api",
     ":apps:order-api",
     ":apps:like-api",
+    ":apps:pbo-api",
     ":apps:commerce-collector",
     ":apps:commerce-batch",
     ":apps:pg-simulator",


### PR DESCRIPTION
## Summary
- PBO(Platform Business Operation) API 모듈 초기 뼈대 생성
- Spring Boot 애플리케이션, 공통 설정(CORS, MDC 로깅, 에러 핸들링), API 응답 래퍼 구성
- `settings.gradle.kts`에 pbo-api 모듈 등록 및 README.md 프로젝트 구조 갱신

Refs #42

## Test plan
- [x] `./gradlew :apps:pbo-api:build` 빌드 성공 확인
- [x] PBO API 애플리케이션 단독 기동 확인
- [x] commerce-api 기존 빌드에 영향 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)