### PR TITLE
feat(sku): SKU/옵션 도메인 구현 및 API 모듈 책임 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ docker-compose -f ./docker/monitoring-compose.yml up
 ```
 Root
 ├── apps ( Spring Boot 애플리케이션 )
-│   ├── commerce-api      # 상품, 결제, 쿠폰, 랭킹, 리뷰 등 (포트 8080)
+│   ├── commerce-api      # 고객용: 상품·SKU/옵션 조회, 결제, 쿠폰, 랭킹, 리뷰 (포트 8080)
 │   ├── order-api         # 주문, 장바구니 (포트 8081)
 │   ├── like-api          # 좋아요 (포트 8083)
-│   ├── pbo-api           # PBO 물류·재고·매장 운영 (포트 8084)
+│   ├── pbo-api           # 파트너용: SKU/옵션 등록, PBO 물류·재고·매장 운영 (포트 8084)
 │   ├── commerce-collector # 이벤트 수집·메트릭
 │   ├── commerce-batch    # 배치 작업
 │   └── pg-simulator      # PG 결제 시뮬레이터 (Kotlin, 포트 8082)

--- a/apps/commerce-api/src/main/java/com/loopers/application/sku/SkuCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/sku/SkuCriteria.java
@@ -1,0 +1,5 @@
+package com.loopers.application.sku;
+
+public class SkuCriteria {
+    // 쓰기 Criteria는 pbo-api로 이동
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/sku/SkuFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/sku/SkuFacade.java
@@ -1,0 +1,47 @@
+package com.loopers.application.sku;
+
+import com.loopers.domain.product.option.ProductOption;
+import com.loopers.domain.product.option.ProductOptionService;
+import com.loopers.domain.product.sku.ProductSku;
+import com.loopers.domain.product.sku.ProductSkuOption;
+import com.loopers.domain.product.sku.ProductSkuService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SkuFacade {
+
+    private final ProductOptionService productOptionService;
+    private final ProductSkuService productSkuService;
+
+    @Transactional(readOnly = true)
+    public SkuResult.OptionList getOptions(Long productId) {
+        List<ProductOption> options = productOptionService.getOptionsByProductId(productId);
+        return SkuResult.OptionList.from(options);
+    }
+
+    @Transactional(readOnly = true)
+    public SkuResult.Sku getSku(Long skuId) {
+        ProductSku sku = productSkuService.getSku(skuId);
+        List<Long> optionIds = sku.getSkuOptions().stream()
+                .map(ProductSkuOption::getOptionId)
+                .toList();
+        List<ProductOption> options = productOptionService.findAllByIdIn(optionIds);
+        return SkuResult.Sku.from(sku, options);
+    }
+
+    @Transactional(readOnly = true)
+    public SkuResult.SkuList getSkusByProduct(Long productId) {
+        List<ProductSku> skus = productSkuService.getSkusByProductId(productId);
+        return SkuResult.SkuList.from(skus, sku -> {
+            List<Long> optionIds = sku.getSkuOptions().stream()
+                    .map(ProductSkuOption::getOptionId)
+                    .toList();
+            return productOptionService.findAllByIdIn(optionIds);
+        });
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/sku/SkuResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/sku/SkuResult.java
@@ -1,0 +1,58 @@
+package com.loopers.application.sku;
+
+import com.loopers.domain.product.option.OptionType;
+import com.loopers.domain.product.option.ProductOption;
+import com.loopers.domain.product.sku.ProductSku;
+
+import java.util.List;
+import java.util.function.Function;
+
+public class SkuResult {
+
+    public record Option(Long id, Long productId, OptionType optionType, String optionValue) {
+
+        public static Option from(ProductOption option) {
+            return new Option(
+                    option.getId(),
+                    option.getProductId(),
+                    option.getOptionType(),
+                    option.getOptionValue()
+            );
+        }
+    }
+
+    public record OptionList(List<Option> options) {
+
+        public static OptionList from(List<ProductOption> options) {
+            return new OptionList(options.stream().map(Option::from).toList());
+        }
+    }
+
+    public record Sku(Long id, Long productId, String skuCode, Long additionalPrice, List<SkuOption> options) {
+
+        public record SkuOption(Long id, OptionType optionType, String optionValue) {
+        }
+
+        public static Sku from(ProductSku sku, List<ProductOption> options) {
+            List<SkuOption> skuOptions = options.stream()
+                    .map(o -> new SkuOption(o.getId(), o.getOptionType(), o.getOptionValue()))
+                    .toList();
+            return new Sku(
+                    sku.getId(),
+                    sku.getProductId(),
+                    sku.getSkuCode(),
+                    sku.getAdditionalPrice(),
+                    skuOptions
+            );
+        }
+    }
+
+    public record SkuList(List<Sku> skus) {
+
+        public static SkuList from(List<ProductSku> skuList, Function<ProductSku, List<ProductOption>> optionLoader) {
+            return new SkuList(skuList.stream()
+                    .map(sku -> Sku.from(sku, optionLoader.apply(sku)))
+                    .toList());
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/option/OptionType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/option/OptionType.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.product.option;
+
+public enum OptionType {
+    COLOR, SIZE, VOLUME, MATERIAL
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/option/ProductOption.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/option/ProductOption.java
@@ -1,0 +1,44 @@
+package com.loopers.domain.product.option;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "product_option")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductOption extends BaseEntity {
+
+    @Column(name = "ref_product_id", nullable = false)
+    private Long productId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "option_type", nullable = false, length = 20)
+    private OptionType optionType;
+
+    @Column(name = "option_value", nullable = false)
+    private String optionValue;
+
+    @Builder
+    private ProductOption(Long productId, OptionType optionType, String optionValue) {
+        this.productId = productId;
+        this.optionType = optionType;
+        this.optionValue = optionValue;
+    }
+
+    public static ProductOption create(Long productId, OptionType optionType, String optionValue) {
+        return ProductOption.builder()
+                .productId(productId)
+                .optionType(optionType)
+                .optionValue(optionValue)
+                .build();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/option/ProductOptionCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/option/ProductOptionCommand.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.product.option;
+
+public class ProductOptionCommand {
+
+    public record Create(Long productId, OptionType optionType, String optionValue) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/option/ProductOptionInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/option/ProductOptionInfo.java
@@ -1,0 +1,13 @@
+package com.loopers.domain.product.option;
+
+public record ProductOptionInfo(Long id, Long productId, OptionType optionType, String optionValue) {
+
+    public static ProductOptionInfo from(ProductOption option) {
+        return new ProductOptionInfo(
+                option.getId(),
+                option.getProductId(),
+                option.getOptionType(),
+                option.getOptionValue()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/option/ProductOptionRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/option/ProductOptionRepository.java
@@ -1,0 +1,14 @@
+package com.loopers.domain.product.option;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductOptionRepository {
+    ProductOption save(ProductOption option);
+
+    Optional<ProductOption> findById(Long id);
+
+    List<ProductOption> findByProductId(Long productId);
+
+    List<ProductOption> findAllByIdIn(List<Long> ids);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/option/ProductOptionService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/option/ProductOptionService.java
@@ -1,0 +1,34 @@
+package com.loopers.domain.product.option;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProductOptionService {
+
+    private final ProductOptionRepository productOptionRepository;
+
+    @Transactional
+    public ProductOption register(ProductOptionCommand.Create command) {
+        ProductOption option = ProductOption.create(
+                command.productId(),
+                command.optionType(),
+                command.optionValue()
+        );
+        return productOptionRepository.save(option);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductOption> getOptionsByProductId(Long productId) {
+        return productOptionRepository.findByProductId(productId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductOption> findAllByIdIn(List<Long> optionIds) {
+        return productOptionRepository.findAllByIdIn(optionIds);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/sku/ProductSku.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/sku/ProductSku.java
@@ -1,0 +1,53 @@
+package com.loopers.domain.product.sku;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "product_sku")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductSku extends BaseEntity {
+
+    @Column(name = "ref_product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "sku_code", nullable = false, unique = true)
+    private String skuCode;
+
+    @Column(name = "additional_price", nullable = false)
+    private Long additionalPrice;
+
+    @OneToMany(mappedBy = "sku", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProductSkuOption> skuOptions = new ArrayList<>();
+
+    @Builder
+    private ProductSku(Long productId, String skuCode, Long additionalPrice) {
+        this.productId = productId;
+        this.skuCode = skuCode;
+        this.additionalPrice = additionalPrice;
+    }
+
+    public static ProductSku create(Long productId, String skuCode, Long additionalPrice) {
+        return ProductSku.builder()
+                .productId(productId)
+                .skuCode(skuCode)
+                .additionalPrice(additionalPrice)
+                .build();
+    }
+
+    public void addOption(ProductSkuOption skuOption) {
+        this.skuOptions.add(skuOption);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/sku/ProductSkuCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/sku/ProductSkuCommand.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.product.sku;
+
+import java.util.List;
+
+public class ProductSkuCommand {
+
+    public record Create(Long productId, String skuCode, Long additionalPrice, List<Long> optionIds) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/sku/ProductSkuInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/sku/ProductSkuInfo.java
@@ -1,0 +1,19 @@
+package com.loopers.domain.product.sku;
+
+import java.util.List;
+
+public record ProductSkuInfo(Long id, Long productId, String skuCode, Long additionalPrice, List<Long> optionIds) {
+
+    public static ProductSkuInfo from(ProductSku sku) {
+        List<Long> optionIds = sku.getSkuOptions().stream()
+                .map(ProductSkuOption::getOptionId)
+                .toList();
+        return new ProductSkuInfo(
+                sku.getId(),
+                sku.getProductId(),
+                sku.getSkuCode(),
+                sku.getAdditionalPrice(),
+                optionIds
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/sku/ProductSkuOption.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/sku/ProductSkuOption.java
@@ -1,0 +1,40 @@
+package com.loopers.domain.product.sku;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "product_sku_option")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductSkuOption extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ref_sku_id", nullable = false)
+    private ProductSku sku;
+
+    @Column(name = "ref_option_id", nullable = false)
+    private Long optionId;
+
+    @Builder
+    private ProductSkuOption(ProductSku sku, Long optionId) {
+        this.sku = sku;
+        this.optionId = optionId;
+    }
+
+    public static ProductSkuOption create(ProductSku sku, Long optionId) {
+        return ProductSkuOption.builder()
+                .sku(sku)
+                .optionId(optionId)
+                .build();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/sku/ProductSkuRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/sku/ProductSkuRepository.java
@@ -1,0 +1,14 @@
+package com.loopers.domain.product.sku;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductSkuRepository {
+    ProductSku save(ProductSku sku);
+
+    Optional<ProductSku> findById(Long skuId);
+
+    List<ProductSku> findByProductId(Long productId);
+
+    boolean existsBySkuCode(String skuCode);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/sku/ProductSkuService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/sku/ProductSkuService.java
@@ -1,0 +1,69 @@
+package com.loopers.domain.product.sku;
+
+import com.loopers.domain.product.option.ProductOption;
+import com.loopers.domain.product.option.ProductOptionRepository;
+import com.loopers.domain.product.sku.exception.SkuException;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class ProductSkuService {
+
+    private final ProductSkuRepository productSkuRepository;
+    private final ProductOptionRepository productOptionRepository;
+
+    @Transactional
+    public ProductSku createSku(ProductSkuCommand.Create command) {
+        List<ProductOption> options = productOptionRepository.findAllByIdIn(command.optionIds());
+
+        if (options.size() != command.optionIds().size()) {
+            throw new CoreException(ErrorType.OPTION_NOT_FOUND, "요청한 옵션 중 존재하지 않는 옵션이 있습니다.");
+        }
+
+        boolean allBelongToProduct = options.stream()
+                .allMatch(option -> option.getProductId().equals(command.productId()));
+        if (!allBelongToProduct) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "옵션이 해당 상품에 속하지 않습니다.");
+        }
+
+        List<ProductSku> existingSkus = productSkuRepository.findByProductId(command.productId());
+        Set<Long> newOptionIds = new HashSet<>(command.optionIds());
+
+        boolean isDuplicate = existingSkus.stream()
+                .anyMatch(sku -> {
+                    Set<Long> existingOptionIds = new HashSet<>();
+                    sku.getSkuOptions().forEach(o -> existingOptionIds.add(o.getOptionId()));
+                    return existingOptionIds.equals(newOptionIds);
+                });
+
+        if (isDuplicate) {
+            throw new SkuException.DuplicateOptionCombinationException(ErrorType.DUPLICATE_SKU_OPTION_COMBINATION);
+        }
+
+        ProductSku sku = ProductSku.create(command.productId(), command.skuCode(), command.additionalPrice());
+        for (Long optionId : command.optionIds()) {
+            sku.addOption(ProductSkuOption.create(sku, optionId));
+        }
+
+        return productSkuRepository.save(sku);
+    }
+
+    @Transactional(readOnly = true)
+    public ProductSku getSku(Long skuId) {
+        return productSkuRepository.findById(skuId)
+                .orElseThrow(() -> new SkuException.SkuNotFoundException(ErrorType.SKU_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductSku> getSkusByProductId(Long productId) {
+        return productSkuRepository.findByProductId(productId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/sku/exception/SkuException.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/sku/exception/SkuException.java
@@ -1,0 +1,19 @@
+package com.loopers.domain.product.sku.exception;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+
+public class SkuException {
+
+    public static class SkuNotFoundException extends CoreException {
+        public SkuNotFoundException(ErrorType errorType) {
+            super(errorType);
+        }
+    }
+
+    public static class DuplicateOptionCombinationException extends CoreException {
+        public DuplicateOptionCombinationException(ErrorType errorType) {
+            super(errorType);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/stock/Stock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/stock/Stock.java
@@ -18,8 +18,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Stock extends BaseEntity {
 
-    @Column(name = "ref_product_id" , nullable = false)
+    @Column(name = "ref_product_id", nullable = false)
     private Long productId;
+
+    @Column(name = "ref_sku_id", nullable = true)
+    private Long skuId;
+
     private Long quantity;
 
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/option/ProductOptionCoreRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/option/ProductOptionCoreRepository.java
@@ -1,0 +1,36 @@
+package com.loopers.infrastructure.product.option;
+
+import com.loopers.domain.product.option.ProductOption;
+import com.loopers.domain.product.option.ProductOptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductOptionCoreRepository implements ProductOptionRepository {
+
+    private final ProductOptionJpaRepository jpaRepository;
+
+    @Override
+    public ProductOption save(ProductOption option) {
+        return jpaRepository.save(option);
+    }
+
+    @Override
+    public Optional<ProductOption> findById(Long id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public List<ProductOption> findByProductId(Long productId) {
+        return jpaRepository.findByProductId(productId);
+    }
+
+    @Override
+    public List<ProductOption> findAllByIdIn(List<Long> ids) {
+        return jpaRepository.findAllById(ids);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/option/ProductOptionJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/option/ProductOptionJpaRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.infrastructure.product.option;
+
+import com.loopers.domain.product.option.ProductOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProductOptionJpaRepository extends JpaRepository<ProductOption, Long> {
+
+    List<ProductOption> findByProductId(Long productId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/sku/ProductSkuCoreRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/sku/ProductSkuCoreRepository.java
@@ -1,0 +1,36 @@
+package com.loopers.infrastructure.product.sku;
+
+import com.loopers.domain.product.sku.ProductSku;
+import com.loopers.domain.product.sku.ProductSkuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductSkuCoreRepository implements ProductSkuRepository {
+
+    private final ProductSkuJpaRepository jpaRepository;
+
+    @Override
+    public ProductSku save(ProductSku sku) {
+        return jpaRepository.save(sku);
+    }
+
+    @Override
+    public Optional<ProductSku> findById(Long skuId) {
+        return jpaRepository.findWithOptionsById(skuId);
+    }
+
+    @Override
+    public List<ProductSku> findByProductId(Long productId) {
+        return jpaRepository.findByProductId(productId);
+    }
+
+    @Override
+    public boolean existsBySkuCode(String skuCode) {
+        return jpaRepository.existsBySkuCode(skuCode);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/sku/ProductSkuJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/sku/ProductSkuJpaRepository.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.product.sku;
+
+import com.loopers.domain.product.sku.ProductSku;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductSkuJpaRepository extends JpaRepository<ProductSku, Long> {
+
+    @EntityGraph(attributePaths = {"skuOptions"})
+    List<ProductSku> findByProductId(Long productId);
+
+    @EntityGraph(attributePaths = {"skuOptions"})
+    Optional<ProductSku> findWithOptionsById(Long id);
+
+    boolean existsBySkuCode(String skuCode);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/sku/ProductSkuOptionJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/sku/ProductSkuOptionJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.product.sku;
+
+import com.loopers.domain.product.sku.ProductSkuOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductSkuOptionJpaRepository extends JpaRepository<ProductSkuOption, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/sku/SkuV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/sku/SkuV1ApiSpec.java
@@ -1,0 +1,25 @@
+package com.loopers.interfaces.api.sku;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Sku V1 API", description = "SKU / 상품 옵션 조회 API 입니다.")
+public interface SkuV1ApiSpec {
+
+    @Operation(summary = "상품별 옵션 목록 조회", description = "상품 ID로 등록된 옵션 목록을 조회합니다.")
+    ApiResponse<SkuV1Dto.Response.OptionList> getOptions(
+            @PathVariable("productId") Long productId
+    );
+
+    @Operation(summary = "SKU 단건 조회", description = "SKU ID로 SKU 정보를 조회합니다.")
+    ApiResponse<SkuV1Dto.Response.Sku> getSku(
+            @PathVariable("skuId") Long skuId
+    );
+
+    @Operation(summary = "상품별 SKU 목록 조회", description = "상품 ID로 등록된 SKU 목록을 조회합니다.")
+    ApiResponse<SkuV1Dto.Response.SkuList> getSkusByProduct(
+            @PathVariable("productId") Long productId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/sku/SkuV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/sku/SkuV1Controller.java
@@ -1,0 +1,37 @@
+package com.loopers.interfaces.api.sku;
+
+import com.loopers.application.sku.SkuFacade;
+import com.loopers.application.sku.SkuResult;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SkuV1Controller implements SkuV1ApiSpec {
+
+    private final SkuFacade skuFacade;
+
+    @GetMapping("/api/v1/products/{productId}/options")
+    @Override
+    public ApiResponse<SkuV1Dto.Response.OptionList> getOptions(@PathVariable Long productId) {
+        SkuResult.OptionList result = skuFacade.getOptions(productId);
+        return ApiResponse.success(SkuV1Dto.Response.OptionList.from(result));
+    }
+
+    @GetMapping("/api/v1/skus/{skuId}")
+    @Override
+    public ApiResponse<SkuV1Dto.Response.Sku> getSku(@PathVariable Long skuId) {
+        SkuResult.Sku result = skuFacade.getSku(skuId);
+        return ApiResponse.success(SkuV1Dto.Response.Sku.from(result));
+    }
+
+    @GetMapping("/api/v1/products/{productId}/skus")
+    @Override
+    public ApiResponse<SkuV1Dto.Response.SkuList> getSkusByProduct(@PathVariable Long productId) {
+        SkuResult.SkuList result = skuFacade.getSkusByProduct(productId);
+        return ApiResponse.success(SkuV1Dto.Response.SkuList.from(result));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/sku/SkuV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/sku/SkuV1Dto.java
@@ -1,0 +1,46 @@
+package com.loopers.interfaces.api.sku;
+
+import com.loopers.application.sku.SkuResult;
+import com.loopers.domain.product.option.OptionType;
+
+import java.util.List;
+
+public class SkuV1Dto {
+
+    public static class Response {
+
+        public record Option(Long id, Long productId, OptionType optionType, String optionValue) {
+
+            public static Option from(SkuResult.Option result) {
+                return new Option(result.id(), result.productId(), result.optionType(), result.optionValue());
+            }
+        }
+
+        public record OptionList(List<Option> options) {
+
+            public static OptionList from(SkuResult.OptionList result) {
+                return new OptionList(result.options().stream().map(Option::from).toList());
+            }
+        }
+
+        public record Sku(Long id, Long productId, String skuCode, Long additionalPrice, List<SkuOption> options) {
+
+            public record SkuOption(Long id, OptionType optionType, String optionValue) {
+            }
+
+            public static Sku from(SkuResult.Sku result) {
+                List<SkuOption> options = result.options().stream()
+                        .map(o -> new SkuOption(o.id(), o.optionType(), o.optionValue()))
+                        .toList();
+                return new Sku(result.id(), result.productId(), result.skuCode(), result.additionalPrice(), options);
+            }
+        }
+
+        public record SkuList(List<Sku> skus) {
+
+            public static SkuList from(SkuResult.SkuList result) {
+                return new SkuList(result.skus().stream().map(Sku::from).toList());
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
@@ -50,7 +50,12 @@ public enum ErrorType {
     REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "Review Already Exists", "이미 해당 상품에 리뷰를 작성했습니다."),
     REVIEW_NOT_OWNER(HttpStatus.FORBIDDEN, "Review Not Owner", "리뷰 작성자만 수정/삭제할 수 있습니다."),
     REVIEW_ORDER_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "Review Order Not Completed", "구매 확정된 주문만 리뷰를 작성할 수 있습니다."),
-    REVIEW_INVALID_RATING(HttpStatus.BAD_REQUEST, "Review Invalid Rating", "평점은 1~5 사이여야 합니다.");
+    REVIEW_INVALID_RATING(HttpStatus.BAD_REQUEST, "Review Invalid Rating", "평점은 1~5 사이여야 합니다."),
+
+    // SKU / 옵션 관련 에러
+    SKU_NOT_FOUND(HttpStatus.NOT_FOUND, "Sku Not Found", "존재하지 않는 SKU입니다."),
+    OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "Option Not Found", "존재하지 않는 옵션입니다."),
+    DUPLICATE_SKU_OPTION_COMBINATION(HttpStatus.CONFLICT, "Duplicate Sku Option Combination", "동일한 옵션 조합의 SKU가 이미 존재합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/apps/commerce-api/src/test/java/com/loopers/application/sku/SkuFacadeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/sku/SkuFacadeTest.java
@@ -1,0 +1,101 @@
+package com.loopers.application.sku;
+
+import com.loopers.domain.product.option.OptionType;
+import com.loopers.domain.product.option.ProductOption;
+import com.loopers.domain.product.option.ProductOptionService;
+import com.loopers.domain.product.sku.ProductSku;
+import com.loopers.domain.product.sku.ProductSkuOption;
+import com.loopers.domain.product.sku.ProductSkuService;
+import com.loopers.domain.product.sku.exception.SkuException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+
+@ExtendWith(MockitoExtension.class)
+class SkuFacadeTest {
+
+    @InjectMocks
+    SkuFacade skuFacade;
+
+    @Mock
+    ProductOptionService productOptionService;
+
+    @Mock
+    ProductSkuService productSkuService;
+
+    @DisplayName("SKU 단건 조회")
+    @Nested
+    class GetSku {
+
+        @DisplayName("SKU를 정상적으로 조회한다.")
+        @Test
+        void getSku_success() {
+            // given
+            Long skuId = 1L;
+            ProductSku sku = ProductSku.create(1L, "P001-RED-M", 0L);
+            sku.addOption(ProductSkuOption.create(sku, 10L));
+
+            ProductOption option = ProductOption.create(1L, OptionType.COLOR, "빨강");
+
+            doReturn(sku).when(productSkuService).getSku(skuId);
+            doReturn(List.of(option)).when(productOptionService).findAllByIdIn(List.of(10L));
+
+            // when
+            SkuResult.Sku result = skuFacade.getSku(skuId);
+
+            // then
+            assertAll(
+                    () -> assertThat(result.skuCode()).isEqualTo("P001-RED-M"),
+                    () -> assertThat(result.options()).hasSize(1)
+            );
+        }
+
+        @DisplayName("존재하지 않는 SKU 조회 시 예외를 그대로 전파한다.")
+        @Test
+        void throwException_whenSkuNotFound() {
+            // given
+            doThrow(new SkuException.SkuNotFoundException(com.loopers.support.error.ErrorType.SKU_NOT_FOUND))
+                    .when(productSkuService).getSku(999L);
+
+            // when & then
+            assertThatThrownBy(() -> skuFacade.getSku(999L))
+                    .isInstanceOf(SkuException.SkuNotFoundException.class);
+        }
+    }
+
+    @DisplayName("상품별 SKU 목록 조회")
+    @Nested
+    class GetSkusByProduct {
+
+        @DisplayName("상품의 SKU 목록을 조회한다.")
+        @Test
+        void getSkusByProduct_success() {
+            // given
+            Long productId = 1L;
+            ProductSku sku1 = ProductSku.create(productId, "P001-RED-M", 0L);
+            ProductSku sku2 = ProductSku.create(productId, "P001-BLUE-L", 1000L);
+
+            doReturn(List.of(sku1, sku2)).when(productSkuService).getSkusByProductId(productId);
+            doReturn(List.of()).when(productOptionService).findAllByIdIn(any());
+
+            // when
+            SkuResult.SkuList result = skuFacade.getSkusByProduct(productId);
+
+            // then
+            assertThat(result.skus()).hasSize(2);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/sku/ProductSkuServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/sku/ProductSkuServiceTest.java
@@ -1,0 +1,169 @@
+package com.loopers.domain.product.sku;
+
+import com.loopers.domain.product.option.OptionType;
+import com.loopers.domain.product.option.ProductOption;
+import com.loopers.domain.product.option.ProductOptionRepository;
+import com.loopers.domain.product.sku.exception.SkuException;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class ProductSkuServiceTest {
+
+    @InjectMocks
+    ProductSkuService productSkuService;
+
+    @Mock
+    ProductSkuRepository productSkuRepository;
+
+    @Mock
+    ProductOptionRepository productOptionRepository;
+
+    @DisplayName("SKU 생성")
+    @Nested
+    class CreateSku {
+
+        @DisplayName("유효한 옵션 조합으로 SKU를 생성한다.")
+        @Test
+        void createSku_success() {
+            // given
+            Long productId = 1L;
+            ProductOption colorOption = ProductOption.create(productId, OptionType.COLOR, "빨강");
+            ProductOption sizeOption = ProductOption.create(productId, OptionType.SIZE, "M");
+
+            ProductSkuCommand.Create command = new ProductSkuCommand.Create(
+                    productId, "P001-RED-M", 0L, List.of(1L, 2L)
+            );
+
+            ProductSku savedSku = ProductSku.create(productId, "P001-RED-M", 0L);
+
+            doReturn(List.of(colorOption, sizeOption)).when(productOptionRepository).findAllByIdIn(List.of(1L, 2L));
+            doReturn(List.of()).when(productSkuRepository).findByProductId(productId);
+            doReturn(savedSku).when(productSkuRepository).save(any(ProductSku.class));
+
+            // when
+            ProductSku result = productSkuService.createSku(command);
+
+            // then
+            assertThat(result.getProductId()).isEqualTo(productId);
+            assertThat(result.getSkuCode()).isEqualTo("P001-RED-M");
+        }
+
+        @DisplayName("동일한 옵션 조합의 SKU가 이미 존재하면 예외를 던진다.")
+        @Test
+        void throwException_whenDuplicateOptionCombination() {
+            // given
+            Long productId = 1L;
+            ProductOption colorOption = ProductOption.create(productId, OptionType.COLOR, "빨강");
+            ProductOption sizeOption = ProductOption.create(productId, OptionType.SIZE, "M");
+
+            ProductSkuCommand.Create command = new ProductSkuCommand.Create(
+                    productId, "P001-RED-M", 0L, List.of(1L, 2L)
+            );
+
+            // 기존 SKU가 동일한 옵션 조합을 가지고 있는 경우
+            ProductSku existingSku = ProductSku.create(productId, "P001-RED-M-OLD", 0L);
+            existingSku.addOption(ProductSkuOption.create(existingSku, 1L));
+            existingSku.addOption(ProductSkuOption.create(existingSku, 2L));
+
+            doReturn(List.of(colorOption, sizeOption)).when(productOptionRepository).findAllByIdIn(List.of(1L, 2L));
+            doReturn(List.of(existingSku)).when(productSkuRepository).findByProductId(productId);
+
+            // when & then
+            assertThatThrownBy(() -> productSkuService.createSku(command))
+                    .isInstanceOf(SkuException.DuplicateOptionCombinationException.class);
+        }
+
+        @DisplayName("다른 상품에 속한 옵션을 사용하면 예외를 던진다.")
+        @Test
+        void throwException_whenOptionBelongsToAnotherProduct() {
+            // given
+            Long productId = 1L;
+            Long anotherProductId = 2L;
+
+            // 다른 상품에 속한 옵션
+            ProductOption colorOption = ProductOption.create(anotherProductId, OptionType.COLOR, "빨강");
+            ProductOption sizeOption = ProductOption.create(productId, OptionType.SIZE, "M");
+
+            ProductSkuCommand.Create command = new ProductSkuCommand.Create(
+                    productId, "P001-RED-M", 0L, List.of(1L, 2L)
+            );
+
+            doReturn(List.of(colorOption, sizeOption)).when(productOptionRepository).findAllByIdIn(List.of(1L, 2L));
+
+            // when & then
+            assertThatThrownBy(() -> productSkuService.createSku(command))
+                    .isInstanceOf(CoreException.class)
+                    .satisfies(ex -> assertThat(((CoreException) ex).getErrorType()).isEqualTo(ErrorType.BAD_REQUEST));
+        }
+
+        @DisplayName("존재하지 않는 옵션 ID가 포함되어 있으면 예외를 던진다.")
+        @Test
+        void throwException_whenOptionNotFound() {
+            // given
+            Long productId = 1L;
+            ProductSkuCommand.Create command = new ProductSkuCommand.Create(
+                    productId, "P001-RED-M", 0L, List.of(1L, 2L)
+            );
+
+            // 옵션 하나만 반환 (하나는 존재하지 않음)
+            ProductOption colorOption = ProductOption.create(productId, OptionType.COLOR, "빨강");
+            doReturn(List.of(colorOption)).when(productOptionRepository).findAllByIdIn(List.of(1L, 2L));
+
+            // when & then
+            assertThatThrownBy(() -> productSkuService.createSku(command))
+                    .isInstanceOf(CoreException.class)
+                    .satisfies(ex -> assertThat(((CoreException) ex).getErrorType()).isEqualTo(ErrorType.OPTION_NOT_FOUND));
+        }
+    }
+
+    @DisplayName("SKU 단건 조회")
+    @Nested
+    class GetSku {
+
+        @DisplayName("존재하지 않는 SKU ID로 조회 시 예외를 던진다.")
+        @Test
+        void throwException_whenSkuNotFound() {
+            // given
+            doReturn(Optional.empty()).when(productSkuRepository).findById(999L);
+
+            // when & then
+            assertThatThrownBy(() -> productSkuService.getSku(999L))
+                    .isInstanceOf(SkuException.SkuNotFoundException.class);
+        }
+
+        @DisplayName("존재하는 SKU ID로 조회 시 SKU를 반환한다.")
+        @Test
+        void getSku_success() {
+            // given
+            Long skuId = 1L;
+            ProductSku sku = ProductSku.create(1L, "P001-RED-M", 0L);
+            doReturn(Optional.of(sku)).when(productSkuRepository).findById(skuId);
+
+            // when
+            ProductSku result = productSkuService.getSku(skuId);
+
+            // then
+            assertThat(result.getSkuCode()).isEqualTo("P001-RED-M");
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/sku/SkuV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/sku/SkuV1ApiE2ETest.java
@@ -1,0 +1,198 @@
+package com.loopers.interfaces.api.sku;
+
+import com.loopers.annotation.SprintE2ETest;
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.category.Category;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.option.OptionType;
+import com.loopers.domain.product.option.ProductOption;
+import com.loopers.domain.product.sku.ProductSku;
+import com.loopers.domain.product.sku.ProductSkuOption;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.utils.DatabaseCleanUp;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@RequiredArgsConstructor
+@SprintE2ETest
+class SkuV1ApiE2ETest {
+
+    private final TestRestTemplate testRestTemplate;
+    private final DatabaseCleanUp databaseCleanUp;
+    private final TestEntityManager testEntityManager;
+    private final TransactionTemplate transactionTemplate;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    private Product persistProduct() {
+        Brand brand = Brand.create("Nike", "Just Do It");
+        transactionTemplate.executeWithoutResult(status -> testEntityManager.persist(brand));
+
+        Category category = Category.createRoot("상의", 1);
+        transactionTemplate.executeWithoutResult(status -> testEntityManager.persist(category));
+
+        Product product = Product.create("운동화", 100000L, brand, category.getId(), null, ZonedDateTime.now());
+        transactionTemplate.executeWithoutResult(status -> testEntityManager.persist(product));
+
+        return product;
+    }
+
+    @DisplayName("GET /api/v1/products/{productId}/options")
+    @Nested
+    class GetOptions {
+
+        @DisplayName("상품별 옵션 목록을 조회한다.")
+        @Test
+        void getOptions_success() {
+            // given
+            Product product = persistProduct();
+
+            ProductOption option1 = ProductOption.create(product.getId(), OptionType.COLOR, "빨강");
+            ProductOption option2 = ProductOption.create(product.getId(), OptionType.SIZE, "M");
+            transactionTemplate.executeWithoutResult(status -> {
+                testEntityManager.persist(option1);
+                testEntityManager.persist(option2);
+            });
+
+            String url = UriComponentsBuilder.fromPath("/api/v1/products/{productId}/options")
+                    .buildAndExpand(product.getId())
+                    .toUriString();
+
+            ParameterizedTypeReference<ApiResponse<SkuV1Dto.Response.OptionList>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<SkuV1Dto.Response.OptionList>> response =
+                    testRestTemplate.exchange(url, HttpMethod.GET, HttpEntity.EMPTY, responseType);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody().data().options()).hasSize(2)
+            );
+        }
+    }
+
+    @DisplayName("GET /api/v1/skus/{skuId}")
+    @Nested
+    class GetSku {
+
+        @DisplayName("SKU를 정상적으로 조회한다.")
+        @Test
+        void getSku_success() {
+            // given
+            Product product = persistProduct();
+
+            ProductOption colorOption = ProductOption.create(product.getId(), OptionType.COLOR, "빨강");
+            transactionTemplate.executeWithoutResult(status -> testEntityManager.persist(colorOption));
+
+            ProductSku sku = ProductSku.create(product.getId(), "P001-RED", 0L);
+            transactionTemplate.executeWithoutResult(status -> {
+                testEntityManager.persist(sku);
+                testEntityManager.persist(ProductSkuOption.create(sku, colorOption.getId()));
+            });
+
+            String url = UriComponentsBuilder.fromPath("/api/v1/skus/{skuId}")
+                    .buildAndExpand(sku.getId())
+                    .toUriString();
+
+            ParameterizedTypeReference<ApiResponse<SkuV1Dto.Response.Sku>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<SkuV1Dto.Response.Sku>> response =
+                    testRestTemplate.exchange(url, HttpMethod.GET, HttpEntity.EMPTY, responseType);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody().data().skuCode()).isEqualTo("P001-RED"),
+                    () -> assertThat(response.getBody().data().options()).hasSize(1)
+            );
+        }
+
+        @DisplayName("존재하지 않는 SKU ID로 조회 시 404를 반환한다.")
+        @Test
+        void throwException_whenSkuNotFound() {
+            // given
+            String url = UriComponentsBuilder.fromPath("/api/v1/skus/{skuId}")
+                    .buildAndExpand(9999L)
+                    .toUriString();
+
+            ParameterizedTypeReference<ApiResponse<SkuV1Dto.Response.Sku>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<SkuV1Dto.Response.Sku>> response =
+                    testRestTemplate.exchange(url, HttpMethod.GET, HttpEntity.EMPTY, responseType);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @DisplayName("GET /api/v1/products/{productId}/skus")
+    @Nested
+    class GetSkusByProduct {
+
+        @DisplayName("상품별 SKU 목록을 조회한다.")
+        @Test
+        void getSkusByProduct_success() {
+            // given
+            Product product = persistProduct();
+
+            ProductOption colorOption = ProductOption.create(product.getId(), OptionType.COLOR, "빨강");
+            ProductOption sizeOption = ProductOption.create(product.getId(), OptionType.SIZE, "M");
+            transactionTemplate.executeWithoutResult(status -> {
+                testEntityManager.persist(colorOption);
+                testEntityManager.persist(sizeOption);
+            });
+
+            ProductSku sku1 = ProductSku.create(product.getId(), "P001-RED", 0L);
+            ProductSku sku2 = ProductSku.create(product.getId(), "P001-M", 0L);
+            transactionTemplate.executeWithoutResult(status -> {
+                testEntityManager.persist(sku1);
+                testEntityManager.persist(ProductSkuOption.create(sku1, colorOption.getId()));
+                testEntityManager.persist(sku2);
+                testEntityManager.persist(ProductSkuOption.create(sku2, sizeOption.getId()));
+            });
+
+            String url = UriComponentsBuilder.fromPath("/api/v1/products/{productId}/skus")
+                    .buildAndExpand(product.getId())
+                    .toUriString();
+
+            ParameterizedTypeReference<ApiResponse<SkuV1Dto.Response.SkuList>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<SkuV1Dto.Response.SkuList>> response =
+                    testRestTemplate.exchange(url, HttpMethod.GET, HttpEntity.EMPTY, responseType);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody().data().skus()).hasSize(2)
+            );
+        }
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/application/sku/SkuCriteria.java
+++ b/apps/pbo-api/src/main/java/com/loopers/application/sku/SkuCriteria.java
@@ -1,0 +1,14 @@
+package com.loopers.application.sku;
+
+import com.loopers.domain.product.option.OptionType;
+
+import java.util.List;
+
+public class SkuCriteria {
+
+    public record RegisterOption(Long productId, OptionType optionType, String optionValue) {
+    }
+
+    public record RegisterSku(Long productId, String skuCode, Long additionalPrice, List<Long> optionIds) {
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/application/sku/SkuFacade.java
+++ b/apps/pbo-api/src/main/java/com/loopers/application/sku/SkuFacade.java
@@ -1,0 +1,63 @@
+package com.loopers.application.sku;
+
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.product.option.ProductOption;
+import com.loopers.domain.product.option.ProductOptionCommand;
+import com.loopers.domain.product.option.ProductOptionService;
+import com.loopers.domain.product.sku.ProductSku;
+import com.loopers.domain.product.sku.ProductSkuCommand;
+import com.loopers.domain.product.sku.ProductSkuOption;
+import com.loopers.domain.product.sku.ProductSkuService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SkuFacade {
+
+    private final ProductService productService;
+    private final ProductOptionService productOptionService;
+    private final ProductSkuService productSkuService;
+
+    @Transactional
+    public SkuResult.Option registerOption(SkuCriteria.RegisterOption criteria) {
+        productService.assertExists(criteria.productId());
+
+        ProductOption option = productOptionService.register(
+                new ProductOptionCommand.Create(criteria.productId(), criteria.optionType(), criteria.optionValue())
+        );
+        return SkuResult.Option.from(option);
+    }
+
+    @Transactional
+    public SkuResult.Sku registerSku(SkuCriteria.RegisterSku criteria) {
+        productService.assertExists(criteria.productId());
+
+        List<ProductOption> options = productOptionService.findAllByIdIn(criteria.optionIds());
+        if (options.size() != criteria.optionIds().size()) {
+            throw new CoreException(ErrorType.OPTION_NOT_FOUND, "요청한 옵션 중 존재하지 않는 옵션이 있습니다.");
+        }
+
+        ProductSku sku = productSkuService.createSku(
+                new ProductSkuCommand.Create(
+                        criteria.productId(),
+                        criteria.skuCode(),
+                        criteria.additionalPrice(),
+                        criteria.optionIds(),
+                        options
+                )
+        );
+
+        List<Long> optionIds = sku.getSkuOptions().stream()
+                .map(ProductSkuOption::getOptionId)
+                .toList();
+        return SkuResult.Sku.from(sku, options.stream()
+                .filter(o -> optionIds.contains(o.getId()))
+                .toList());
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/application/sku/SkuResult.java
+++ b/apps/pbo-api/src/main/java/com/loopers/application/sku/SkuResult.java
@@ -1,0 +1,41 @@
+package com.loopers.application.sku;
+
+import com.loopers.domain.product.option.OptionType;
+import com.loopers.domain.product.option.ProductOption;
+import com.loopers.domain.product.sku.ProductSku;
+
+import java.util.List;
+
+public class SkuResult {
+
+    public record Option(Long id, Long productId, OptionType optionType, String optionValue) {
+
+        public static Option from(ProductOption option) {
+            return new Option(
+                    option.getId(),
+                    option.getProductId(),
+                    option.getOptionType(),
+                    option.getOptionValue()
+            );
+        }
+    }
+
+    public record Sku(Long id, Long productId, String skuCode, Long additionalPrice, List<SkuOption> options) {
+
+        public record SkuOption(Long id, OptionType optionType, String optionValue) {
+        }
+
+        public static Sku from(ProductSku sku, List<ProductOption> options) {
+            List<SkuOption> skuOptions = options.stream()
+                    .map(o -> new SkuOption(o.getId(), o.getOptionType(), o.getOptionValue()))
+                    .toList();
+            return new Sku(
+                    sku.getId(),
+                    sku.getProductId(),
+                    sku.getSkuCode(),
+                    sku.getAdditionalPrice(),
+                    skuOptions
+            );
+        }
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/pbo-api/src/main/java/com/loopers/domain/product/Product.java
@@ -1,0 +1,21 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * pbo-api에서 상품 존재 여부 확인용 최소 엔티티.
+ * product 테이블 읽기 전용(existsById).
+ */
+@Entity
+@Table(name = "product")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product extends BaseEntity {
+
+    public static Product create() {
+        return new Product();
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/pbo-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.product;
+
+public interface ProductRepository {
+    boolean existsById(Long productId);
+}

--- a/apps/pbo-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/pbo-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -1,0 +1,21 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.product.exception.ProductException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    @Transactional(readOnly = true)
+    public void assertExists(Long productId) {
+        if (!productRepository.existsById(productId)) {
+            throw new ProductException.ProductNotFoundException(ErrorType.PRODUCT_NOT_FOUND);
+        }
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/domain/product/exception/ProductException.java
+++ b/apps/pbo-api/src/main/java/com/loopers/domain/product/exception/ProductException.java
@@ -1,0 +1,13 @@
+package com.loopers.domain.product.exception;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+
+public class ProductException {
+
+    public static class ProductNotFoundException extends CoreException {
+        public ProductNotFoundException(ErrorType errorType) {
+            super(errorType);
+        }
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/domain/product/option/OptionType.java
+++ b/apps/pbo-api/src/main/java/com/loopers/domain/product/option/OptionType.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.product.option;
+
+public enum OptionType {
+    COLOR, SIZE, VOLUME, MATERIAL
+}

--- a/apps/pbo-api/src/main/java/com/loopers/domain/product/option/ProductOption.java
+++ b/apps/pbo-api/src/main/java/com/loopers/domain/product/option/ProductOption.java
@@ -1,0 +1,44 @@
+package com.loopers.domain.product.option;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "product_option")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductOption extends BaseEntity {
+
+    @Column(name = "ref_product_id", nullable = false)
+    private Long productId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "option_type", nullable = false, length = 20)
+    private OptionType optionType;
+
+    @Column(name = "option_value", nullable = false)
+    private String optionValue;
+
+    @Builder
+    private ProductOption(Long productId, OptionType optionType, String optionValue) {
+        this.productId = productId;
+        this.optionType = optionType;
+        this.optionValue = optionValue;
+    }
+
+    public static ProductOption create(Long productId, OptionType optionType, String optionValue) {
+        return ProductOption.builder()
+                .productId(productId)
+                .optionType(optionType)
+                .optionValue(optionValue)
+                .build();
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/domain/product/option/ProductOptionCommand.java
+++ b/apps/pbo-api/src/main/java/com/loopers/domain/product/option/ProductOptionCommand.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.product.option;
+
+public class ProductOptionCommand {
+
+    public record Create(Long productId, OptionType optionType, String optionValue) {
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/domain/product/option/ProductOptionRepository.java
+++ b/apps/pbo-api/src/main/java/com/loopers/domain/product/option/ProductOptionRepository.java
@@ -1,0 +1,14 @@
+package com.loopers.domain.product.option;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductOptionRepository {
+    ProductOption save(ProductOption option);
+
+    Optional<ProductOption> findById(Long id);
+
+    List<ProductOption> findByProductId(Long productId);
+
+    List<ProductOption> findAllByIdIn(List<Long> ids);
+}

--- a/apps/pbo-api/src/main/java/com/loopers/domain/product/option/ProductOptionService.java
+++ b/apps/pbo-api/src/main/java/com/loopers/domain/product/option/ProductOptionService.java
@@ -1,0 +1,29 @@
+package com.loopers.domain.product.option;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProductOptionService {
+
+    private final ProductOptionRepository productOptionRepository;
+
+    @Transactional
+    public ProductOption register(ProductOptionCommand.Create command) {
+        ProductOption option = ProductOption.create(
+                command.productId(),
+                command.optionType(),
+                command.optionValue()
+        );
+        return productOptionRepository.save(option);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductOption> findAllByIdIn(List<Long> optionIds) {
+        return productOptionRepository.findAllByIdIn(optionIds);
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/domain/product/sku/ProductSku.java
+++ b/apps/pbo-api/src/main/java/com/loopers/domain/product/sku/ProductSku.java
@@ -1,0 +1,53 @@
+package com.loopers.domain.product.sku;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "product_sku")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductSku extends BaseEntity {
+
+    @Column(name = "ref_product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "sku_code", nullable = false, unique = true)
+    private String skuCode;
+
+    @Column(name = "additional_price", nullable = false)
+    private Long additionalPrice;
+
+    @OneToMany(mappedBy = "sku", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProductSkuOption> skuOptions = new ArrayList<>();
+
+    @Builder
+    private ProductSku(Long productId, String skuCode, Long additionalPrice) {
+        this.productId = productId;
+        this.skuCode = skuCode;
+        this.additionalPrice = additionalPrice;
+    }
+
+    public static ProductSku create(Long productId, String skuCode, Long additionalPrice) {
+        return ProductSku.builder()
+                .productId(productId)
+                .skuCode(skuCode)
+                .additionalPrice(additionalPrice)
+                .build();
+    }
+
+    public void addOption(ProductSkuOption skuOption) {
+        this.skuOptions.add(skuOption);
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/domain/product/sku/ProductSkuCommand.java
+++ b/apps/pbo-api/src/main/java/com/loopers/domain/product/sku/ProductSkuCommand.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.product.sku;
+
+import com.loopers.domain.product.option.ProductOption;
+
+import java.util.List;
+
+public class ProductSkuCommand {
+
+    public record Create(Long productId, String skuCode, Long additionalPrice, List<Long> optionIds, List<ProductOption> validatedOptions) {
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/domain/product/sku/ProductSkuOption.java
+++ b/apps/pbo-api/src/main/java/com/loopers/domain/product/sku/ProductSkuOption.java
@@ -1,0 +1,40 @@
+package com.loopers.domain.product.sku;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "product_sku_option")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductSkuOption extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ref_sku_id", nullable = false)
+    private ProductSku sku;
+
+    @Column(name = "ref_option_id", nullable = false)
+    private Long optionId;
+
+    @Builder
+    private ProductSkuOption(ProductSku sku, Long optionId) {
+        this.sku = sku;
+        this.optionId = optionId;
+    }
+
+    public static ProductSkuOption create(ProductSku sku, Long optionId) {
+        return ProductSkuOption.builder()
+                .sku(sku)
+                .optionId(optionId)
+                .build();
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/domain/product/sku/ProductSkuRepository.java
+++ b/apps/pbo-api/src/main/java/com/loopers/domain/product/sku/ProductSkuRepository.java
@@ -1,0 +1,14 @@
+package com.loopers.domain.product.sku;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductSkuRepository {
+    ProductSku save(ProductSku sku);
+
+    Optional<ProductSku> findById(Long skuId);
+
+    List<ProductSku> findByProductId(Long productId);
+
+    boolean existsBySkuCode(String skuCode);
+}

--- a/apps/pbo-api/src/main/java/com/loopers/domain/product/sku/ProductSkuService.java
+++ b/apps/pbo-api/src/main/java/com/loopers/domain/product/sku/ProductSkuService.java
@@ -1,0 +1,58 @@
+package com.loopers.domain.product.sku;
+
+import com.loopers.domain.product.option.ProductOption;
+import com.loopers.domain.product.sku.exception.SkuException;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ProductSkuService {
+
+    private final ProductSkuRepository productSkuRepository;
+
+    @Transactional
+    public ProductSku createSku(ProductSkuCommand.Create command) {
+        List<ProductOption> options = command.validatedOptions();
+
+        boolean allBelongToProduct = options.stream()
+                .allMatch(option -> option.getProductId().equals(command.productId()));
+        if (!allBelongToProduct) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "옵션이 해당 상품에 속하지 않습니다.");
+        }
+
+        if (productSkuRepository.existsBySkuCode(command.skuCode())) {
+            throw new CoreException(ErrorType.CONFLICT, "이미 사용 중인 SKU 코드입니다.");
+        }
+
+        List<ProductSku> existingSkus = productSkuRepository.findByProductId(command.productId());
+        Set<Long> newOptionIds = new HashSet<>(command.optionIds());
+
+        boolean isDuplicate = existingSkus.stream()
+                .anyMatch(sku -> {
+                    Set<Long> existingOptionIds = sku.getSkuOptions().stream()
+                            .map(ProductSkuOption::getOptionId)
+                            .collect(Collectors.toSet());
+                    return existingOptionIds.equals(newOptionIds);
+                });
+
+        if (isDuplicate) {
+            throw new SkuException.DuplicateOptionCombinationException(ErrorType.DUPLICATE_SKU_OPTION_COMBINATION);
+        }
+
+        ProductSku sku = ProductSku.create(command.productId(), command.skuCode(), command.additionalPrice());
+        for (Long optionId : command.optionIds()) {
+            sku.addOption(ProductSkuOption.create(sku, optionId));
+        }
+
+        return productSkuRepository.save(sku);
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/domain/product/sku/exception/SkuException.java
+++ b/apps/pbo-api/src/main/java/com/loopers/domain/product/sku/exception/SkuException.java
@@ -1,0 +1,19 @@
+package com.loopers.domain.product.sku.exception;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+
+public class SkuException {
+
+    public static class SkuNotFoundException extends CoreException {
+        public SkuNotFoundException(ErrorType errorType) {
+            super(errorType);
+        }
+    }
+
+    public static class DuplicateOptionCombinationException extends CoreException {
+        public DuplicateOptionCombinationException(ErrorType errorType) {
+            super(errorType);
+        }
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/infrastructure/product/ProductCoreRepository.java
+++ b/apps/pbo-api/src/main/java/com/loopers/infrastructure/product/ProductCoreRepository.java
@@ -1,0 +1,17 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductCoreRepository implements ProductRepository {
+
+    private final ProductJpaRepository jpaRepository;
+
+    @Override
+    public boolean existsById(Long productId) {
+        return jpaRepository.existsById(productId);
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/pbo-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductJpaRepository extends JpaRepository<Product, Long> {
+}

--- a/apps/pbo-api/src/main/java/com/loopers/infrastructure/product/option/ProductOptionCoreRepository.java
+++ b/apps/pbo-api/src/main/java/com/loopers/infrastructure/product/option/ProductOptionCoreRepository.java
@@ -1,0 +1,36 @@
+package com.loopers.infrastructure.product.option;
+
+import com.loopers.domain.product.option.ProductOption;
+import com.loopers.domain.product.option.ProductOptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductOptionCoreRepository implements ProductOptionRepository {
+
+    private final ProductOptionJpaRepository jpaRepository;
+
+    @Override
+    public ProductOption save(ProductOption option) {
+        return jpaRepository.save(option);
+    }
+
+    @Override
+    public Optional<ProductOption> findById(Long id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public List<ProductOption> findByProductId(Long productId) {
+        return jpaRepository.findByProductId(productId);
+    }
+
+    @Override
+    public List<ProductOption> findAllByIdIn(List<Long> ids) {
+        return jpaRepository.findAllById(ids);
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/infrastructure/product/option/ProductOptionJpaRepository.java
+++ b/apps/pbo-api/src/main/java/com/loopers/infrastructure/product/option/ProductOptionJpaRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.infrastructure.product.option;
+
+import com.loopers.domain.product.option.ProductOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProductOptionJpaRepository extends JpaRepository<ProductOption, Long> {
+
+    List<ProductOption> findByProductId(Long productId);
+}

--- a/apps/pbo-api/src/main/java/com/loopers/infrastructure/product/sku/ProductSkuCoreRepository.java
+++ b/apps/pbo-api/src/main/java/com/loopers/infrastructure/product/sku/ProductSkuCoreRepository.java
@@ -1,0 +1,36 @@
+package com.loopers.infrastructure.product.sku;
+
+import com.loopers.domain.product.sku.ProductSku;
+import com.loopers.domain.product.sku.ProductSkuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductSkuCoreRepository implements ProductSkuRepository {
+
+    private final ProductSkuJpaRepository jpaRepository;
+
+    @Override
+    public ProductSku save(ProductSku sku) {
+        return jpaRepository.save(sku);
+    }
+
+    @Override
+    public Optional<ProductSku> findById(Long skuId) {
+        return jpaRepository.findById(skuId);
+    }
+
+    @Override
+    public List<ProductSku> findByProductId(Long productId) {
+        return jpaRepository.findByProductId(productId);
+    }
+
+    @Override
+    public boolean existsBySkuCode(String skuCode) {
+        return jpaRepository.existsBySkuCode(skuCode);
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/infrastructure/product/sku/ProductSkuJpaRepository.java
+++ b/apps/pbo-api/src/main/java/com/loopers/infrastructure/product/sku/ProductSkuJpaRepository.java
@@ -1,0 +1,15 @@
+package com.loopers.infrastructure.product.sku;
+
+import com.loopers.domain.product.sku.ProductSku;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProductSkuJpaRepository extends JpaRepository<ProductSku, Long> {
+
+    @EntityGraph(attributePaths = {"skuOptions"})
+    List<ProductSku> findByProductId(Long productId);
+
+    boolean existsBySkuCode(String skuCode);
+}

--- a/apps/pbo-api/src/main/java/com/loopers/infrastructure/product/sku/ProductSkuOptionJpaRepository.java
+++ b/apps/pbo-api/src/main/java/com/loopers/infrastructure/product/sku/ProductSkuOptionJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.product.sku;
+
+import com.loopers.domain.product.sku.ProductSkuOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductSkuOptionJpaRepository extends JpaRepository<ProductSkuOption, Long> {
+}

--- a/apps/pbo-api/src/main/java/com/loopers/interfaces/api/sku/SkuV1ApiSpec.java
+++ b/apps/pbo-api/src/main/java/com/loopers/interfaces/api/sku/SkuV1ApiSpec.java
@@ -1,0 +1,22 @@
+package com.loopers.interfaces.api.sku;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Sku V1 API", description = "SKU / 상품 옵션 등록 API 입니다.")
+public interface SkuV1ApiSpec {
+
+    @Operation(summary = "상품 옵션 등록", description = "상품에 옵션(사이즈, 컬러 등)을 등록합니다.")
+    ApiResponse<SkuV1Dto.Response.Option> registerOption(
+            @PathVariable("productId") Long productId,
+            @RequestBody SkuV1Dto.Request.RegisterOption request
+    );
+
+    @Operation(summary = "SKU 등록", description = "옵션 조합으로 SKU를 등록합니다.")
+    ApiResponse<SkuV1Dto.Response.Sku> registerSku(
+            @RequestBody SkuV1Dto.Request.RegisterSku request
+    );
+}

--- a/apps/pbo-api/src/main/java/com/loopers/interfaces/api/sku/SkuV1Controller.java
+++ b/apps/pbo-api/src/main/java/com/loopers/interfaces/api/sku/SkuV1Controller.java
@@ -1,0 +1,48 @@
+package com.loopers.interfaces.api.sku;
+
+import com.loopers.application.sku.SkuCriteria;
+import com.loopers.application.sku.SkuFacade;
+import com.loopers.application.sku.SkuResult;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SkuV1Controller implements SkuV1ApiSpec {
+
+    private final SkuFacade skuFacade;
+
+    @PostMapping("/api/v1/products/{productId}/options")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Override
+    public ApiResponse<SkuV1Dto.Response.Option> registerOption(
+            @PathVariable Long productId,
+            @RequestBody SkuV1Dto.Request.RegisterOption request
+    ) {
+        SkuResult.Option result = skuFacade.registerOption(
+                new SkuCriteria.RegisterOption(productId, request.optionType(), request.optionValue())
+        );
+        return ApiResponse.success(SkuV1Dto.Response.Option.from(result));
+    }
+
+    @PostMapping("/api/v1/skus")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Override
+    public ApiResponse<SkuV1Dto.Response.Sku> registerSku(@RequestBody SkuV1Dto.Request.RegisterSku request) {
+        SkuResult.Sku result = skuFacade.registerSku(
+                new SkuCriteria.RegisterSku(
+                        request.productId(),
+                        request.skuCode(),
+                        request.additionalPrice(),
+                        request.optionIds()
+                )
+        );
+        return ApiResponse.success(SkuV1Dto.Response.Sku.from(result));
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/interfaces/api/sku/SkuV1Dto.java
+++ b/apps/pbo-api/src/main/java/com/loopers/interfaces/api/sku/SkuV1Dto.java
@@ -1,0 +1,41 @@
+package com.loopers.interfaces.api.sku;
+
+import com.loopers.application.sku.SkuResult;
+import com.loopers.domain.product.option.OptionType;
+
+import java.util.List;
+
+public class SkuV1Dto {
+
+    public static class Request {
+
+        public record RegisterOption(OptionType optionType, String optionValue) {
+        }
+
+        public record RegisterSku(Long productId, String skuCode, Long additionalPrice, List<Long> optionIds) {
+        }
+    }
+
+    public static class Response {
+
+        public record Option(Long id, Long productId, OptionType optionType, String optionValue) {
+
+            public static Option from(SkuResult.Option result) {
+                return new Option(result.id(), result.productId(), result.optionType(), result.optionValue());
+            }
+        }
+
+        public record Sku(Long id, Long productId, String skuCode, Long additionalPrice, List<SkuOption> options) {
+
+            public record SkuOption(Long id, OptionType optionType, String optionValue) {
+            }
+
+            public static Sku from(SkuResult.Sku result) {
+                List<SkuOption> options = result.options().stream()
+                        .map(o -> new SkuOption(o.id(), o.optionType(), o.optionValue()))
+                        .toList();
+                return new Sku(result.id(), result.productId(), result.skuCode(), result.additionalPrice(), options);
+            }
+        }
+    }
+}

--- a/apps/pbo-api/src/main/java/com/loopers/support/error/ErrorType.java
+++ b/apps/pbo-api/src/main/java/com/loopers/support/error/ErrorType.java
@@ -10,7 +10,14 @@ public enum ErrorType {
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(), "일시적인 오류가 발생했습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "잘못된 요청입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.getReasonPhrase(), "존재하지 않는 요청입니다."),
-    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다.");
+    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다."),
+
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "Product Not Found", "존재하지 않는 상품입니다."),
+
+    // SKU / 옵션 관련 에러
+    SKU_NOT_FOUND(HttpStatus.NOT_FOUND, "Sku Not Found", "존재하지 않는 SKU입니다."),
+    OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "Option Not Found", "존재하지 않는 옵션입니다."),
+    DUPLICATE_SKU_OPTION_COMBINATION(HttpStatus.CONFLICT, "Duplicate Sku Option Combination", "동일한 옵션 조합의 SKU가 이미 존재합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/apps/pbo-api/src/test/java/com/loopers/application/sku/SkuFacadeTest.java
+++ b/apps/pbo-api/src/test/java/com/loopers/application/sku/SkuFacadeTest.java
@@ -1,0 +1,152 @@
+package com.loopers.application.sku;
+
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.product.exception.ProductException;
+import com.loopers.domain.product.option.OptionType;
+import com.loopers.domain.product.option.ProductOption;
+import com.loopers.domain.product.option.ProductOptionService;
+import com.loopers.domain.product.sku.ProductSku;
+import com.loopers.domain.product.sku.ProductSkuOption;
+import com.loopers.domain.product.sku.ProductSkuService;
+import com.loopers.domain.product.sku.exception.SkuException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+
+@ExtendWith(MockitoExtension.class)
+class SkuFacadeTest {
+
+    @InjectMocks
+    SkuFacade skuFacade;
+
+    @Mock
+    ProductService productService;
+
+    @Mock
+    ProductOptionService productOptionService;
+
+    @Mock
+    ProductSkuService productSkuService;
+
+    @DisplayName("상품 옵션 등록")
+    @Nested
+    class RegisterOption {
+
+        @DisplayName("옵션을 정상적으로 등록한다.")
+        @Test
+        void registerOption_success() {
+            // given
+            Long productId = 1L;
+            SkuCriteria.RegisterOption criteria = new SkuCriteria.RegisterOption(productId, OptionType.COLOR, "빨강");
+
+            ProductOption savedOption = ProductOption.create(productId, OptionType.COLOR, "빨강");
+            doReturn(savedOption).when(productOptionService).register(any());
+
+            // when
+            SkuResult.Option result = skuFacade.registerOption(criteria);
+
+            // then
+            assertAll(
+                    () -> assertThat(result.productId()).isEqualTo(productId),
+                    () -> assertThat(result.optionType()).isEqualTo(OptionType.COLOR),
+                    () -> assertThat(result.optionValue()).isEqualTo("빨강")
+            );
+        }
+
+        @DisplayName("존재하지 않는 상품에 옵션 등록 시 예외를 던진다.")
+        @Test
+        void throwException_whenProductNotFound() {
+            // given
+            SkuCriteria.RegisterOption criteria = new SkuCriteria.RegisterOption(999L, OptionType.COLOR, "빨강");
+            doThrow(new ProductException.ProductNotFoundException(ErrorType.PRODUCT_NOT_FOUND))
+                    .when(productService).assertExists(999L);
+
+            // when & then
+            assertThatThrownBy(() -> skuFacade.registerOption(criteria))
+                    .isInstanceOf(ProductException.ProductNotFoundException.class);
+        }
+    }
+
+    @DisplayName("SKU 등록")
+    @Nested
+    class RegisterSku {
+
+        @DisplayName("SKU를 정상적으로 등록한다.")
+        @Test
+        void registerSku_success() {
+            // given
+            Long productId = 1L;
+            SkuCriteria.RegisterSku criteria = new SkuCriteria.RegisterSku(productId, "P001-RED-M", 0L, List.of(1L, 2L));
+
+            ProductOption colorOption = ProductOption.create(productId, OptionType.COLOR, "빨강");
+            ProductOption sizeOption = ProductOption.create(productId, OptionType.SIZE, "M");
+
+            ProductSku sku = ProductSku.create(productId, "P001-RED-M", 0L);
+            sku.addOption(ProductSkuOption.create(sku, 1L));
+            sku.addOption(ProductSkuOption.create(sku, 2L));
+
+            doReturn(List.of(colorOption, sizeOption)).when(productOptionService).findAllByIdIn(List.of(1L, 2L));
+            doReturn(sku).when(productSkuService).createSku(any());
+
+            // when
+            SkuResult.Sku result = skuFacade.registerSku(criteria);
+
+            // then
+            assertAll(
+                    () -> assertThat(result.productId()).isEqualTo(productId),
+                    () -> assertThat(result.skuCode()).isEqualTo("P001-RED-M")
+            );
+        }
+
+        @DisplayName("중복 옵션 조합 등록 시 예외를 그대로 전파한다.")
+        @Test
+        void throwException_whenDuplicateOptionCombination() {
+            // given
+            Long productId = 1L;
+            SkuCriteria.RegisterSku criteria = new SkuCriteria.RegisterSku(productId, "P001-RED-M", 0L, List.of(1L, 2L));
+
+            ProductOption colorOption = ProductOption.create(productId, OptionType.COLOR, "빨강");
+            ProductOption sizeOption = ProductOption.create(productId, OptionType.SIZE, "M");
+
+            doReturn(List.of(colorOption, sizeOption)).when(productOptionService).findAllByIdIn(List.of(1L, 2L));
+            doThrow(new SkuException.DuplicateOptionCombinationException(ErrorType.DUPLICATE_SKU_OPTION_COMBINATION))
+                    .when(productSkuService).createSku(any());
+
+            // when & then
+            assertThatThrownBy(() -> skuFacade.registerSku(criteria))
+                    .isInstanceOf(SkuException.DuplicateOptionCombinationException.class);
+        }
+
+        @DisplayName("존재하지 않는 옵션 ID 포함 시 예외를 던진다.")
+        @Test
+        void throwException_whenOptionNotFound() {
+            // given
+            Long productId = 1L;
+            SkuCriteria.RegisterSku criteria = new SkuCriteria.RegisterSku(productId, "P001-RED-M", 0L, List.of(1L, 2L));
+
+            // 옵션 하나만 반환 (하나는 존재하지 않음)
+            ProductOption colorOption = ProductOption.create(productId, OptionType.COLOR, "빨강");
+            doReturn(List.of(colorOption)).when(productOptionService).findAllByIdIn(List.of(1L, 2L));
+
+            // when & then
+            assertThatThrownBy(() -> skuFacade.registerSku(criteria))
+                    .isInstanceOf(com.loopers.support.error.CoreException.class)
+                    .satisfies(ex -> assertThat(((com.loopers.support.error.CoreException) ex).getErrorType())
+                            .isEqualTo(ErrorType.OPTION_NOT_FOUND));
+        }
+    }
+}

--- a/apps/pbo-api/src/test/java/com/loopers/domain/product/sku/ProductSkuServiceTest.java
+++ b/apps/pbo-api/src/test/java/com/loopers/domain/product/sku/ProductSkuServiceTest.java
@@ -1,0 +1,125 @@
+package com.loopers.domain.product.sku;
+
+import com.loopers.domain.product.option.OptionType;
+import com.loopers.domain.product.option.ProductOption;
+import com.loopers.domain.product.sku.exception.SkuException;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class ProductSkuServiceTest {
+
+    @InjectMocks
+    ProductSkuService productSkuService;
+
+    @Mock
+    ProductSkuRepository productSkuRepository;
+
+    @DisplayName("SKU 생성")
+    @Nested
+    class CreateSku {
+
+        @DisplayName("유효한 옵션 조합으로 SKU를 생성한다.")
+        @Test
+        void createSku_success() {
+            // given
+            Long productId = 1L;
+            ProductOption colorOption = ProductOption.create(productId, OptionType.COLOR, "빨강");
+            ProductOption sizeOption = ProductOption.create(productId, OptionType.SIZE, "M");
+
+            ProductSkuCommand.Create command = new ProductSkuCommand.Create(
+                    productId, "P001-RED-M", 0L, List.of(1L, 2L), List.of(colorOption, sizeOption)
+            );
+
+            ProductSku savedSku = ProductSku.create(productId, "P001-RED-M", 0L);
+
+            doReturn(false).when(productSkuRepository).existsBySkuCode("P001-RED-M");
+            doReturn(List.of()).when(productSkuRepository).findByProductId(productId);
+            doReturn(savedSku).when(productSkuRepository).save(any(ProductSku.class));
+
+            // when
+            ProductSku result = productSkuService.createSku(command);
+
+            // then
+            assertThat(result.getProductId()).isEqualTo(productId);
+            assertThat(result.getSkuCode()).isEqualTo("P001-RED-M");
+        }
+
+        @DisplayName("동일한 옵션 조합의 SKU가 이미 존재하면 예외를 던진다.")
+        @Test
+        void throwException_whenDuplicateOptionCombination() {
+            // given
+            Long productId = 1L;
+            ProductOption colorOption = ProductOption.create(productId, OptionType.COLOR, "빨강");
+            ProductOption sizeOption = ProductOption.create(productId, OptionType.SIZE, "M");
+
+            ProductSkuCommand.Create command = new ProductSkuCommand.Create(
+                    productId, "P001-RED-M", 0L, List.of(1L, 2L), List.of(colorOption, sizeOption)
+            );
+
+            ProductSku existingSku = ProductSku.create(productId, "P001-RED-M-OLD", 0L);
+            existingSku.addOption(ProductSkuOption.create(existingSku, 1L));
+            existingSku.addOption(ProductSkuOption.create(existingSku, 2L));
+
+            doReturn(false).when(productSkuRepository).existsBySkuCode("P001-RED-M");
+            doReturn(List.of(existingSku)).when(productSkuRepository).findByProductId(productId);
+
+            // when & then
+            assertThatThrownBy(() -> productSkuService.createSku(command))
+                    .isInstanceOf(SkuException.DuplicateOptionCombinationException.class);
+        }
+
+        @DisplayName("다른 상품에 속한 옵션을 사용하면 예외를 던진다.")
+        @Test
+        void throwException_whenOptionBelongsToAnotherProduct() {
+            // given
+            Long productId = 1L;
+            Long anotherProductId = 2L;
+
+            ProductOption colorOption = ProductOption.create(anotherProductId, OptionType.COLOR, "빨강");
+            ProductOption sizeOption = ProductOption.create(productId, OptionType.SIZE, "M");
+
+            ProductSkuCommand.Create command = new ProductSkuCommand.Create(
+                    productId, "P001-RED-M", 0L, List.of(1L, 2L), List.of(colorOption, sizeOption)
+            );
+
+            // when & then
+            assertThatThrownBy(() -> productSkuService.createSku(command))
+                    .isInstanceOf(CoreException.class)
+                    .satisfies(ex -> assertThat(((CoreException) ex).getErrorType()).isEqualTo(ErrorType.BAD_REQUEST));
+        }
+
+        @DisplayName("이미 사용 중인 SKU 코드이면 예외를 던진다.")
+        @Test
+        void throwException_whenSkuCodeAlreadyExists() {
+            // given
+            Long productId = 1L;
+            ProductOption colorOption = ProductOption.create(productId, OptionType.COLOR, "빨강");
+
+            ProductSkuCommand.Create command = new ProductSkuCommand.Create(
+                    productId, "P001-RED", 0L, List.of(1L), List.of(colorOption)
+            );
+
+            doReturn(true).when(productSkuRepository).existsBySkuCode("P001-RED");
+
+            // when & then
+            assertThatThrownBy(() -> productSkuService.createSku(command))
+                    .isInstanceOf(CoreException.class)
+                    .satisfies(ex -> assertThat(((CoreException) ex).getErrorType()).isEqualTo(ErrorType.CONFLICT));
+        }
+    }
+}

--- a/apps/pbo-api/src/test/java/com/loopers/interfaces/api/sku/SkuV1ApiE2ETest.java
+++ b/apps/pbo-api/src/test/java/com/loopers/interfaces/api/sku/SkuV1ApiE2ETest.java
@@ -1,0 +1,229 @@
+package com.loopers.interfaces.api.sku;
+
+import com.loopers.annotation.SprintE2ETest;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.option.OptionType;
+import com.loopers.domain.product.option.ProductOption;
+import com.loopers.domain.product.sku.ProductSku;
+import com.loopers.domain.product.sku.ProductSkuOption;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.utils.DatabaseCleanUp;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@RequiredArgsConstructor
+@SprintE2ETest
+class SkuV1ApiE2ETest {
+
+    private final TestRestTemplate testRestTemplate;
+    private final DatabaseCleanUp databaseCleanUp;
+    private final TestEntityManager testEntityManager;
+    private final TransactionTemplate transactionTemplate;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    private Product persistProduct() {
+        Product product = Product.create();
+        transactionTemplate.executeWithoutResult(status -> testEntityManager.persist(product));
+        return product;
+    }
+
+    @DisplayName("POST /api/v1/products/{productId}/options")
+    @Nested
+    class RegisterOption {
+
+        @DisplayName("상품 옵션을 정상적으로 등록하고 201을 반환한다.")
+        @Test
+        void registerOption_success() {
+            // given
+            Product product = persistProduct();
+
+            String url = UriComponentsBuilder.fromPath("/api/v1/products/{productId}/options")
+                    .buildAndExpand(product.getId())
+                    .toUriString();
+
+            SkuV1Dto.Request.RegisterOption request = new SkuV1Dto.Request.RegisterOption(OptionType.COLOR, "빨강");
+            HttpEntity<SkuV1Dto.Request.RegisterOption> requestEntity = new HttpEntity<>(request);
+
+            ParameterizedTypeReference<ApiResponse<SkuV1Dto.Response.Option>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<SkuV1Dto.Response.Option>> response =
+                    testRestTemplate.exchange(url, HttpMethod.POST, requestEntity, responseType);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED),
+                    () -> assertThat(response.getBody().data().productId()).isEqualTo(product.getId()),
+                    () -> assertThat(response.getBody().data().optionType()).isEqualTo(OptionType.COLOR),
+                    () -> assertThat(response.getBody().data().optionValue()).isEqualTo("빨강")
+            );
+        }
+
+        @DisplayName("존재하지 않는 상품에 옵션 등록 시 404를 반환한다.")
+        @Test
+        void throwException_whenProductNotFound() {
+            // given
+            String url = UriComponentsBuilder.fromPath("/api/v1/products/{productId}/options")
+                    .buildAndExpand(9999L)
+                    .toUriString();
+
+            SkuV1Dto.Request.RegisterOption request = new SkuV1Dto.Request.RegisterOption(OptionType.COLOR, "빨강");
+            HttpEntity<SkuV1Dto.Request.RegisterOption> requestEntity = new HttpEntity<>(request);
+
+            ParameterizedTypeReference<ApiResponse<SkuV1Dto.Response.Option>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<SkuV1Dto.Response.Option>> response =
+                    testRestTemplate.exchange(url, HttpMethod.POST, requestEntity, responseType);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @DisplayName("POST /api/v1/skus")
+    @Nested
+    class RegisterSku {
+
+        @DisplayName("SKU를 정상적으로 등록하고 201을 반환한다.")
+        @Test
+        void registerSku_success() {
+            // given
+            Product product = persistProduct();
+
+            ProductOption colorOption = ProductOption.create(product.getId(), OptionType.COLOR, "빨강");
+            ProductOption sizeOption = ProductOption.create(product.getId(), OptionType.SIZE, "M");
+            transactionTemplate.executeWithoutResult(status -> {
+                testEntityManager.persist(colorOption);
+                testEntityManager.persist(sizeOption);
+            });
+
+            SkuV1Dto.Request.RegisterSku request = new SkuV1Dto.Request.RegisterSku(
+                    product.getId(), "P001-RED-M", 0L, List.of(colorOption.getId(), sizeOption.getId())
+            );
+            HttpEntity<SkuV1Dto.Request.RegisterSku> requestEntity = new HttpEntity<>(request);
+
+            ParameterizedTypeReference<ApiResponse<SkuV1Dto.Response.Sku>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<SkuV1Dto.Response.Sku>> response =
+                    testRestTemplate.exchange("/api/v1/skus", HttpMethod.POST, requestEntity, responseType);
+
+            // then
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED),
+                    () -> assertThat(response.getBody().data().productId()).isEqualTo(product.getId()),
+                    () -> assertThat(response.getBody().data().skuCode()).isEqualTo("P001-RED-M"),
+                    () -> assertThat(response.getBody().data().options()).hasSize(2)
+            );
+        }
+
+        @DisplayName("동일한 옵션 조합으로 SKU 등록 시 409를 반환한다.")
+        @Test
+        void throwException_whenDuplicateOptionCombination() {
+            // given
+            Product product = persistProduct();
+
+            ProductOption colorOption = ProductOption.create(product.getId(), OptionType.COLOR, "빨강");
+            ProductOption sizeOption = ProductOption.create(product.getId(), OptionType.SIZE, "M");
+            transactionTemplate.executeWithoutResult(status -> {
+                testEntityManager.persist(colorOption);
+                testEntityManager.persist(sizeOption);
+            });
+
+            // 첫 번째 SKU 등록
+            ProductSku existingSku = ProductSku.create(product.getId(), "P001-RED-M-1", 0L);
+            transactionTemplate.executeWithoutResult(status -> {
+                testEntityManager.persist(existingSku);
+                testEntityManager.persist(ProductSkuOption.create(existingSku, colorOption.getId()));
+                testEntityManager.persist(ProductSkuOption.create(existingSku, sizeOption.getId()));
+            });
+
+            // 두 번째 SKU 등록 (동일 옵션 조합)
+            SkuV1Dto.Request.RegisterSku request = new SkuV1Dto.Request.RegisterSku(
+                    product.getId(), "P001-RED-M-2", 0L, List.of(colorOption.getId(), sizeOption.getId())
+            );
+            HttpEntity<SkuV1Dto.Request.RegisterSku> requestEntity = new HttpEntity<>(request);
+
+            ParameterizedTypeReference<ApiResponse<SkuV1Dto.Response.Sku>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<SkuV1Dto.Response.Sku>> response =
+                    testRestTemplate.exchange("/api/v1/skus", HttpMethod.POST, requestEntity, responseType);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        }
+
+        @DisplayName("타 상품 옵션 사용 시 400을 반환한다.")
+        @Test
+        void throwException_whenOptionBelongsToAnotherProduct() {
+            // given
+            Product product = persistProduct();
+            Product anotherProduct = persistProduct();
+
+            ProductOption anotherOption = ProductOption.create(anotherProduct.getId(), OptionType.COLOR, "파랑");
+            transactionTemplate.executeWithoutResult(status -> testEntityManager.persist(anotherOption));
+
+            SkuV1Dto.Request.RegisterSku request = new SkuV1Dto.Request.RegisterSku(
+                    product.getId(), "P001-BLUE", 0L, List.of(anotherOption.getId())
+            );
+            HttpEntity<SkuV1Dto.Request.RegisterSku> requestEntity = new HttpEntity<>(request);
+
+            ParameterizedTypeReference<ApiResponse<SkuV1Dto.Response.Sku>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<SkuV1Dto.Response.Sku>> response =
+                    testRestTemplate.exchange("/api/v1/skus", HttpMethod.POST, requestEntity, responseType);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+
+        @DisplayName("존재하지 않는 상품 ID로 SKU 등록 시 404를 반환한다.")
+        @Test
+        void throwException_whenProductNotFound() {
+            // given
+            SkuV1Dto.Request.RegisterSku request = new SkuV1Dto.Request.RegisterSku(
+                    9999L, "P001-RED-M", 0L, List.of(1L)
+            );
+            HttpEntity<SkuV1Dto.Request.RegisterSku> requestEntity = new HttpEntity<>(request);
+
+            ParameterizedTypeReference<ApiResponse<SkuV1Dto.Response.Sku>> responseType =
+                    new ParameterizedTypeReference<>() {};
+
+            // when
+            ResponseEntity<ApiResponse<SkuV1Dto.Response.Sku>> response =
+                    testRestTemplate.exchange("/api/v1/skus", HttpMethod.POST, requestEntity, responseType);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/apps/pbo-api/src/test/resources/application.yml
+++ b/apps/pbo-api/src/test/resources/application.yml
@@ -1,0 +1,26 @@
+spring:
+  profiles:
+    active: test
+  jpa:
+    hibernate:
+      ddl-auto: create
+
+datasource:
+  mysql-jpa:
+    main:
+      jdbc-url: jdbc:mysql://localhost:3306/loopers
+      username: application
+      password: application
+
+  redis:
+    database: 0
+    master:
+      host: localhost
+      port: 6379
+    replicas:
+      - host: localhost
+        port: 6380
+
+service:
+  commerce-api:
+    url: http://localhost:8080


### PR DESCRIPTION
## Summary
- **commerce-api (조회 전용)**: ProductOption, ProductSku 도메인 구현 + GET API 3개
  - `GET /api/v1/products/{productId}/options`
  - `GET /api/v1/skus/{skuId}`
  - `GET /api/v1/products/{productId}/skus`
- **pbo-api (등록 전용)**: 동일 DB 테이블 공유 패턴으로 SKU/옵션 쓰기 담당 + POST API 2개
  - `POST /api/v1/products/{productId}/options`
  - `POST /api/v1/skus`
- 아키텍처 규칙 준수: `Facade → ProductService.assertExists() → ProductRepository` (infrastructure 직접 의존 금지)
- `ProductSkuService`의 타 도메인 Repository 직접 의존 제거: `ProductSkuCommand.Create`에 `validatedOptions` 포함, Facade에서 옵션 검증 후 전달
- SKU 코드 중복 검증(409) 및 동일 옵션 조합 중복 검증(409) 추가
- ErrorType 추가: `SKU_NOT_FOUND`, `OPTION_NOT_FOUND`, `DUPLICATE_SKU_OPTION_COMBINATION`

## Test plan
- [x] commerce-api: `ProductSkuServiceTest` — SKU 생성 도메인 단위 테스트
- [x] commerce-api: `SkuFacadeTest` — GET 조회 Facade 단위 테스트
- [x] commerce-api: `SkuV1ApiE2ETest` — GET API E2E 테스트 (옵션 목록, SKU 단건, SKU 목록)
- [x] pbo-api: `ProductSkuServiceTest` — SKU 생성, 중복 조합, 타 상품 옵션, SKU 코드 중복 검증
- [x] pbo-api: `SkuFacadeTest` — 옵션 등록, SKU 등록, 옵션 미존재 예외 전파
- [x] pbo-api: `SkuV1ApiE2ETest` — POST 201, 409(중복 조합), 400(타 상품 옵션), 404(상품 미존재)

🤖 Generated with [Claude Code](https://claude.com/claude-code)